### PR TITLE
Track total hits true

### DIFF
--- a/backend/src/buildRequest.ts
+++ b/backend/src/buildRequest.ts
@@ -255,6 +255,7 @@ export default function buildRequest(requestInput: RequestBodyInterface): BodyRe
     // --------------------------
     // https://www.elastic.co/guide/en/elasticsearch/reference/7.x/search-request-highlighting.html
     min_score: (requestInput.fullText.value ? 5: 0),
+    track_total_hits: true,
     // highlight: {
     //   fragment_size: 200,
     //   number_of_fragments: 1,


### PR DESCRIPTION
Ultra simple commit to enable full count.
Should have impact of elasticsearch performance, but not much after some queries directly into api/v0 of deces.matchid.id, and a real count is very useful for genealogists.

Same evol made to the deces-ui api/v0 version in https://github.com/matchID-project/deces-ui/pull/143/commits/15bbcb1ffa9d353c37a6bf2a6c72588e6e5c4344