### PR TITLE
add deathAge and sex as sort options

### DIFF
--- a/backend/src/buildRequest.ts
+++ b/backend/src/buildRequest.ts
@@ -227,11 +227,13 @@ const referenceSort: any = {
   score: "_score",
   firstName: "PRENOM.raw",
   lastName: "NOM.raw",
+  sex: "SEXE",
   birthDate: "DATE_NAISSANCE.raw",
   birthCity: "COMMUNE_NAISSANCE.raw",
   birthDepartment: "DEPARTEMENT_NAISSANCE",
   birthCountry: "PAYS_NAISSANCE.raw",
   deathDate: "DATE_DECES.raw",
+  deathAge: "AGE_DECES",
   deathCity: "COMMUNE_DECES.raw",
   deathDepartment: "DEPARTEMENT_DECES",
   deathCountry: "PAYS_DECES.raw"


### PR DESCRIPTION
2 lines feat (or fix) : sort by age and sex were missing - as used in table sort in deces-ui, causing a 500 error