### PR TITLE
enable first and last name inversion in fuzzy advanced query mode

### DIFF
--- a/backend/src/fieldsWithQueries.ts
+++ b/backend/src/fieldsWithQueries.ts
@@ -1,4 +1,4 @@
-import { GeoPoint } from './types/requestBodyInterface';
+import { GeoPoint, Name } from './types/requestBodyInterface';
 
 import {
     dateRangeValidationMask,
@@ -12,7 +12,7 @@ import {
 import {
     dateRangeStringQuery,
     ageRangeStringQuery,
-    firstNameQuery,
+    nameQuery,
     fuzzyTermQuery,
     geoPointQuery,
     matchQuery
@@ -23,17 +23,16 @@ export const fullTextWithQuery = (value: string, fuzzy: string|boolean) => value
     field: "fullText"
 };
 
-export const firstNameWithQuery = (value: string, fuzzy: string|boolean) => value && {
+export const nameWithQuery = (value: Name, fuzzy: string|boolean) => value && (value.first || value.last) && {
     value,
-    field: ["PRENOM","PRENOMS"],
-    query: firstNameQuery,
-    fuzzy: (fuzzy && fuzzy === 'false') ? false : "auto"
-};
-
-export const lastNameWithQuery = (value: string, fuzzy: string|boolean) => value && {
-    value,
-    field: "NOM",
-    query: fuzzyTermQuery,
+    field: {
+        first: {
+            first: "PRENOM",
+            all: "PRENOMS"
+        },
+        last: "NOM"
+    },
+    query: nameQuery,
     fuzzy: (fuzzy && fuzzy === 'false') ? false : "auto"
 };
 

--- a/backend/src/queries.ts
+++ b/backend/src/queries.ts
@@ -1,4 +1,4 @@
-import { GeoPoint } from './types/requestBodyInterface';
+import { GeoPoint, NameFields, Name } from './types/requestBodyInterface';
 
 export const prefixQuery = (field: string, value: string, fuzzy: boolean) => {
     return {
@@ -44,7 +44,46 @@ export const fuzzyTermQuery = (field: string, value: string, fuzzy: boolean) => 
     }
 };
 
-export const firstNameQuery = (field: string, value: string, fuzzy: boolean) => {
+export const nameQuery = (field: NameFields, value: Name, fuzzy: boolean) => {
+    if (fuzzy) {
+        return {
+            bool: {
+                minimum_should_match: 1,
+                should: [
+                    {
+                        bool: {
+                            must: [
+                                value.first && firstNameQuery([field.first.first, field.first.all], value.first as string, fuzzy),
+                                value.last && fuzzyTermQuery(field.last as string, value.last as string, fuzzy)
+                            ].filter(x => x),
+                            boost: 2
+                        },
+                    },
+                    value.first && value.last && {
+                        bool: {
+                            must: [
+                                firstNameQuery([field.first.first, field.first.all], value.last as string, fuzzy),
+                                fuzzyTermQuery(field.last as string, value.first as string, fuzzy)
+                            ],
+                            boost: 0.5
+                        }
+                    }
+                ].filter(x => x)
+            }
+        };
+    } else {
+        return {
+            bool: {
+                must: [
+                    value.first && matchQuery(field.first.first, value.first as string, false),
+                    value.last && matchQuery(field.last as string, value.last as string, false)
+                ].filter(x => x)
+            }
+        };
+    }
+}
+
+export const firstNameQuery = (field: string[], value: string, fuzzy: boolean) => {
     if (fuzzy) {
         return {
             bool: {

--- a/backend/src/types/requestBodyInterface.ts
+++ b/backend/src/types/requestBodyInterface.ts
@@ -1,6 +1,6 @@
 export interface Name {
   first: string|string[];
-  name: string|string[];
+  last: string|string[];
 };
 
 export interface GeoPoint {
@@ -35,8 +35,7 @@ export class RequestBodyInterface {
   size: number;
   page: number;
   fullText?: RequestField;
-  firstName?: RequestField;
-  lastName?: RequestField;
+  name?: RequestField;
   sex?: RequestField;
   birthDate?: RequestField;
   birthCity?: RequestField;

--- a/backend/src/types/requestInput.ts
+++ b/backend/src/types/requestInput.ts
@@ -1,7 +1,6 @@
 import {
   fullTextWithQuery,
-  firstNameWithQuery,
-  lastNameWithQuery,
+  nameWithQuery,
   sexWithQuery,
   birthDateWithQuery,
   birthCityWithQuery,
@@ -27,8 +26,10 @@ export class RequestInput extends RequestBodyInterface {
     this.sort = sort ? sort: [{score: 'desc'}];
 
     this.fullText = fullTextWithQuery(q, fuzzy);
-    this.firstName = firstNameWithQuery(firstName, fuzzy);
-    this.lastName = lastNameWithQuery(lastName, fuzzy);
+    this.name = nameWithQuery({
+      first: firstName,
+      last: lastName
+    }, fuzzy);
     this.sex = sexWithQuery(sex, fuzzy);
     this.birthDate = birthDateWithQuery(birthDate, fuzzy);
     this.birthCity = birthCityWithQuery(birthCity, fuzzy);

--- a/backend/src/types/requestInputPost.ts
+++ b/backend/src/types/requestInputPost.ts
@@ -1,7 +1,6 @@
 import {
   fullTextWithQuery,
-  firstNameWithQuery,
-  lastNameWithQuery,
+  nameWithQuery,
   sexWithQuery,
   birthDateWithQuery,
   birthCityWithQuery,
@@ -67,8 +66,10 @@ export class RequestInputPost extends RequestBodyInterface {
     this.sort = requestBody.sort ? requestBody.sort: [{score: 'desc'}];
 
     this.fullText = fullTextWithQuery(requestBody.q, requestBody.fuzzy);
-    this.firstName = firstNameWithQuery(requestBody.firstName, requestBody.fuzzy);
-    this.lastName = lastNameWithQuery(requestBody.lastName, requestBody.fuzzy);
+    this.name = nameWithQuery({
+      first: requestBody.firstName,
+      last: requestBody.lastName
+    }, requestBody.fuzzy);
     this.sex = sexWithQuery(requestBody.sex, requestBody.fuzzy);
     this.birthDate = birthDateWithQuery(requestBody.birthDate, requestBody.fuzzy);
     this.birthCity = birthCityWithQuery(requestBody.birthCity, requestBody.fuzzy);


### PR DESCRIPTION
accept requests like {lastName:philippe firstName:antoine} to match {lastName:antoine firstName:philippe} in advanced mode, as this error sometimes occurs in the dataset (user reported)

this was already done in simple match (q)

this tolerance is only accepted in fuzzy mode. no swap accepted in strict mode.