### PR TITLE
Return response as csv

### DIFF
--- a/backend/src/controllers/bulk.ts
+++ b/backend/src/controllers/bulk.ts
@@ -306,7 +306,7 @@ router.get('/:format(csv|json)/:id?', async (req: any, res: express.Response) =>
   }
 });
 
-const jsonPath = (json: any, path: string): any => {
+export const jsonPath = (json: any, path: string): any => {
   if (!json) { return undefined }
   if (!path.includes('.')) {
     return json[path];
@@ -318,12 +318,11 @@ const jsonPath = (json: any, path: string): any => {
   }
 }
 
-const resultsHeader = [
-  'score', 'source', 'id',
-  'name.last', 'name.first',
-  'sex', 'birth.date', 'birth.location.city',
-  'birth.location.city', 'birth.location.departmentCode', 'birth.location.country',
-  'birth.location.countryCode', 'birth.location.latitude', 'birth.location.longitude',
-  'death.date', 'death.certificateId', 'death.age',
-  'death.location.city', 'death.location.cityCode', 'death.location.departmentCode',
-  'death.location.country', 'death.location.countryCode', 'death.location.latitude', 'death.location.Longitude']
+export const resultsHeader = [
+  'score', 'source', 'id', 'name.last', 'name.first', 'sex',
+  'birth.date', 'birth.location.city', 'birth.location.departmentCode',
+  'birth.location.country', 'birth.location.countryCode', 'birth.location.latitude',
+  'birth.location.longitude',
+  'death.date', 'death.certificateId', 'death.age', 'death.location.city',
+  'death.location.cityCode', 'death.location.departmentCode', 'death.location.country',
+  'death.location.countryCode', 'death.location.latitude', 'death.location.longitude']

--- a/backend/tests/test_query_params.sh
+++ b/backend/tests/test_query_params.sh
@@ -293,3 +293,9 @@ if [ ! -z "$scrollId" ]; then \
 else
     echo -e "\e[31mscroll: KO!\e[0m"
 fi
+if curl -s -X POST -H "Accept: application/csv" -H "Content-Type: application/json" -d '{"deathDate":"2020","lastName": "Pottier"}' http://localhost:${BACKEND_PORT}/deces/api/v1/search | wc -l | grep -q 21; then
+    echo "simple csv response: OK"
+else
+    echo -e "\e[31msimple csv response: KO!\e[0m"
+    exit 1
+fi


### PR DESCRIPTION
For route '/search', when header has "Accept: application/csv" the response will be a csv with the matching identities.

The csv includes the following properties:

```
  'score', 'source', 'id',
  'name', 'firstName', 'lastName',
  'sex', 'birthDate', 'birthCity',
  'cityCode', 'departmentCode', 'country',
  'countryCode', 'latitude', 'longitude',
  'deathDate', 'certificateId', 'age',
  'deathCity', 'cityCode', 'departmentCode',
  'country', 'countryCode', 'latitude', 'longitude'
```

I think they should be renamed using the modifications on #62 