### PR TITLE
Birthday in bulk request and more...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 backend/src/routes
 backend/src/api
+backend/src/api2
 artifacts
 aws
 config

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,9 @@
   "main": "dist/index.js",
   "scripts": {
     "lint": "eslint -c .eslintrc.js  --ext .ts src/ --fix",
-    "tsoa": "mkdir -p src/routes && mkdir -p src/api && tsc src/tsoa.ts --outDir dist && node dist/tsoa.js",
+    "tsoa1": "mkdir -p src/routes && mkdir -p src/api && tsc src/tsoa.ts --outDir dist && node dist/tsoa.js",
+    "tsoa2": "mkdir -p src/routes && mkdir -p src/api2 && tsc src/tsoa2.ts --outDir dist && node dist/tsoa2.js",
+    "tsoa": "npm run tsoa1 && npm run tsoa2",
     "prebuild": "npm run lint && npm run tsoa",
     "build": "tsc --outDir dist",
     "start": "node .",

--- a/backend/src/buildRequest.ts
+++ b/backend/src/buildRequest.ts
@@ -23,8 +23,8 @@ const buildAdaptativeBlockMatch = (searchInput: RequestInput) => {
     let queryMust = [fuzzyTermQuery('PRENOMS_NOM', [searchInput.name.value.last, searchInput.name.value.first].filter(x => x).join(" "), "auto", false)]
     let queryShould = [matchQuery('NOM', searchInput.name.value.last as string, false, false)]
     if (searchInput.birthDate && searchInput.birthDate.value) {
-      queryMust = [...queryMust, fuzzyTermQuery('DATE_NAISSANCE', searchInput.birthDate.mask.transform(searchInput.birthDate.value) as string, "auto", false)]
-      queryShould = [...queryShould, matchQuery('DATE_NAISSANCE', searchInput.birthDate.mask.transform(searchInput.birthDate.value) as string, false, false)]
+      queryMust = [...queryMust, fuzzyTermQuery('DATE_NAISSANCE', searchInput.birthDate.mask.transform(searchInput.birthDate.value, searchInput.dateFormat) as string, "auto", false)]
+      queryShould = [...queryShould, matchQuery('DATE_NAISSANCE', searchInput.birthDate.mask.transform(searchInput.birthDate.value, searchInput.dateFormat) as string, false, false)]
     }
     return {
         function_score : {

--- a/backend/src/buildRequest.ts
+++ b/backend/src/buildRequest.ts
@@ -19,19 +19,19 @@ const buildAdaptativeBlockMatch = (searchInput: RequestInput) => {
   /*
     apply the costless blocking strategy :
   */
-  if (searchInput.name && searchInput.name.value && searchInput.name.value.last && searchInput.name.value.first && searchInput.birthDate.value) {
+  if (searchInput.name && searchInput.name.value && searchInput.name.value.last && searchInput.name.value.first) {
+    let queryMust = [fuzzyTermQuery('PRENOMS_NOM', [searchInput.name.value.last, searchInput.name.value.first].filter(x => x).join(" "), "auto", false)]
+    let queryShould = [matchQuery('NOM', searchInput.name.value.last as string, false, false)]
+    if (searchInput.birthDate && searchInput.birthDate.value) {
+      queryMust = [...queryMust, fuzzyTermQuery('DATE_NAISSANCE', searchInput.birthDate.mask.transform(searchInput.birthDate.value) as string, "auto", false)]
+      queryShould = [...queryShould, matchQuery('DATE_NAISSANCE', searchInput.birthDate.mask.transform(searchInput.birthDate.value) as string, false, false)]
+    }
     return {
         function_score : {
           query: {
             bool: {
-              must: [
-                fuzzyTermQuery('PRENOMS_NOM', [searchInput.name.value.last, searchInput.name.value.first].filter(x => x).join(" "), "auto", false),
-                fuzzyTermQuery('DATE_NAISSANCE', searchInput.birthDate.mask.transform(searchInput.birthDate.value) as string, "auto", false),
-              ],
-              should: [
-                matchQuery('NOM', searchInput.name.value.last as string, false, false),
-                matchQuery('DATE_NAISSANCE', searchInput.birthDate.mask.transform(searchInput.birthDate.value) as string, false, false),
-              ],
+              must: queryMust,
+              should: queryShould,
               minimum_should_match: 1
             }
           }

--- a/backend/src/controllers/bulk.spec.ts
+++ b/backend/src/controllers/bulk.spec.ts
@@ -31,4 +31,21 @@ describe('Process csv', () => {
     expect(result[1].name.last).to.equal('Pierre')
     expect(result[2].name.last).to.equal('Michel')
   });
+
+  it('Passing alternative date format', async () => {
+    const result = await processCsv(
+      {
+        data: {
+          sep: ',',
+          chunkSize: 5,
+          dateFormat: 'YYYY-MM-DD'
+        }
+      },
+      {file: ['firstName,lastName,birthDate', 'jean,pierre,1933-08-04', 'georges,michel,1939-03-12'].join('\r\n')}
+    )
+    expect(result[1]).to.have.property('name')
+    expect(result[2]).to.have.property('name')
+    expect(result[1].name.last).to.equal('Pierre')
+    expect(result[2].name.last).to.equal('Michel')
+  });
 });

--- a/backend/src/controllers/bulk.spec.ts
+++ b/backend/src/controllers/bulk.spec.ts
@@ -17,4 +17,18 @@ describe('Process csv', () => {
     expect(result[0].metadata.mapping.lastName).to.equal('lastName')
     expect(result[1].block.minimum_match).to.equal(1);
   });
+
+  it('Passing only first and last name ', async () => {
+    const result = await processCsv(
+      {
+        data: {
+          sep: ',',
+          chunkSize: 5
+        }
+      },
+      {file: ['firstName,lastName', 'jean,pierre', 'georges,michel'].join('\r\n')}
+    )
+    expect(result[1].name.last).to.equal('Pierre')
+    expect(result[2].name.last).to.equal('Michel')
+  });
 });

--- a/backend/src/controllers/bulk.ts
+++ b/backend/src/controllers/bulk.ts
@@ -359,7 +359,7 @@ router.get('/:format(csv|json)/:id?', async (req: any, res: express.Response) =>
         }
       }
     } else if (job && job.status === 'failed') {
-      res.send({status: job.status, msg: job.options.stacktraces.join(' ')});
+      res.status(400).send({status: job.status, msg: job.options.stacktraces.join(' ')});
     } else if (job) {
       res.send({status: job.status, id: req.params.id, progress: job.progress});
     } else {

--- a/backend/src/controllers/bulk.ts
+++ b/backend/src/controllers/bulk.ts
@@ -402,12 +402,13 @@ export const jsonPath = (json: any, path: string): any => {
 
 export const resultsHeader = [
   'score', 'source', 'id', 'name.last', 'name.first', 'sex',
-  'birth.date', 'birth.location.city', 'birth.location.departmentCode',
-  'birth.location.country', 'birth.location.countryCode', 'birth.location.latitude',
-  'birth.location.longitude',
-  'death.date', 'death.certificateId', 'death.age', 'death.location.city',
-  'death.location.cityCode', 'death.location.departmentCode', 'death.location.country',
-  'death.location.countryCode', 'death.location.latitude', 'death.location.longitude']
+  'birth.date', 'birth.location.city', 'birth.location.cityCode',
+  'birth.location.departmentCode', 'birth.location.country', 'birth.location.countryCode',
+  'birth.location.latitude', 'birth.location.longitude',
+  'death.certificateId', 'death.age',
+  'death.date', 'death.location.city', 'death.location.cityCode',
+  'death.location.departmentCode', 'death.location.country', 'death.location.countryCode',
+  'death.location.latitude', 'death.location.longitude']
 
 interface JobInput {
   id: string;

--- a/backend/src/controllers/documentation.ts
+++ b/backend/src/controllers/documentation.ts
@@ -3,45 +3,59 @@ import { Router } from 'express';
 import swaggerJsdoc from 'swagger-jsdoc';
 import swaggerUi from 'swagger-ui-express';
 import * as swaggerDocument from '../api/swagger.json';
+import * as swaggerDocument2 from '../api2/swagger.json';
 
 export const router = Router();
 
 // Swagger set up
-const options = {
-  swaggerDefinition: {
-    openapi: "3.0.0",
-    info: {
-      title: "API personnes décédées",
-      version: process.env.APP_VERSION,
-      description:
-        "API pour faciliter le rapprochement des personnes decedees",
-      license: {
-        name: "lgpl-3.0",
-        url: "https://choosealicense.com/licenses/lgpl-3.0/"
-      },
-      contact: {
-        name: "MatchID",
-        url: `http${process.env.API_SSL ? 's' : ''}://${process.env.API_URL}`,
-        email: `${process.env.API_EMAIL}`
-      }
+const swaggerDefinitionTemplate: any = {
+  info: {
+    title: "API personnes décédées",
+    version: process.env.APP_VERSION,
+    description:
+    "API pour faciliter le rapprochement des personnes decedees",
+    license: {
+      name: "lgpl-3.0",
+      url: "https://choosealicense.com/licenses/lgpl-3.0/"
     },
-    servers: [
-      {
-        url: `http${process.env.API_SSL ? 's' : ''}://${process.env.API_URL}/deces/api/v1`
-      }
-    ]
+    contact: {
+      name: "MatchID",
+      url: `http${process.env.API_SSL ? 's' : ''}://${process.env.API_URL}`,
+      email: `${process.env.API_EMAIL}`
+    }
   },
+  servers: [
+    {
+      url: `http${process.env.API_SSL ? 's' : ''}://${process.env.API_URL}/deces/api/v1`
+    }
+  ]
+}
+
+const options = {
+  swaggerDefinition: {...swaggerDefinitionTemplate},
   apis: ["**/bulk.{ts,js}"]
-};
-const specs:any = swaggerJsdoc(options);
+}
+options.swaggerDefinition.openapi = '3.0.0'
+const specs: any = swaggerJsdoc(options);
+
+const options2 = {
+  swaggerDefinition: {...swaggerDefinitionTemplate},
+  apis: ["**/bulk.{ts,js}"]
+}
+options2.swaggerDefinition.swagger = '2.0'
+const specs2: any = swaggerJsdoc(options2);
 
 // publish swagger json (optional)
 router.get(`/bulk.json`, (_, res) => res.send(specs));
+router.get(`/bulk2.json`, (_, res) => res.send(specs2));
 router.get(`/tsoa.json`, (_, res) => res.send(swaggerDocument));
+router.get(`/tsoa2.json`, (_, res) => res.send(swaggerDocument2));
 
 specs.paths = {...specs.paths, ...swaggerDocument.paths}
 specs.components = {...specs.components, ...swaggerDocument.components}
 // specs.default = swaggerDocument.default;
 
-router.use(`/`, swaggerUi.serve, swaggerUi.setup(specs));
+specs2.paths = {...specs2.paths, ...swaggerDocument2.paths}
+specs2.definitions = {...specs.definitions, ...swaggerDocument2.definitions}
 
+router.use(`/`, swaggerUi.serve, swaggerUi.setup(specs));

--- a/backend/src/masks.ts
+++ b/backend/src/masks.ts
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import { Sort } from './models/entities'
 
 export const ageValidationMask = (ageString: string) => {
@@ -46,12 +47,16 @@ export const dateTransformMask = (dateString: string|number): string => {
   }
 }
 
-export const dateRangeTransformMask = (dateRangeString: string) => {
-    if (/[0-9\/]+\-[0-9\/]+/.test(dateRangeString)) {
-        return dateRangeString.toString().split('-').map(d => dateTransformMask(d));
+export const dateRangeTransformMask = (dateRangeString: string, dateFormat?: string) => {
+  if (dateFormat) {
+    return moment(dateRangeString.toString(), dateFormat).format("YYYYMMDD");
+  } else {
+    if (/[0-9\/]+\-[0-9\/]+/.test(dateRangeString) && dateRangeString.toString().split('-').length === 2) {
+      return dateRangeString.toString().split('-').map(d => dateTransformMask(d));
     } else {
-        return dateTransformMask(dateRangeString);
+      return dateTransformMask(dateRangeString);
     }
+  }
 }
 
 export const sexValidationMask = (sex: string) => {

--- a/backend/src/models/requestInput.ts
+++ b/backend/src/models/requestInput.ts
@@ -143,15 +143,17 @@ export class RequestInput {
   fuzzy?: string;
   sort?: RequestField;
   block?: Block;
+  dateFormat?: string;
   metadata?: any;
   errors: string[] = [];
-  constructor(q?: string, firstName?: string, lastName?: string, sex?: string, birthDate?: string|number, birthCity?: string, birthDepartment?: string, birthCountry?: string, birthGeoPoint?: GeoPoint, deathDate?: string|number, deathCity?: string, deathDepartment?: string, deathCountry?: string, deathGeoPoint?: GeoPoint, deathAge?: string|number, scroll?: string, scrollId?: string, size?: number, page?: number, fuzzy?: string, sort?: string|Sort[], block?: Block, metadata?: any) {
+  constructor(q?: string, firstName?: string, lastName?: string, sex?: string, birthDate?: string|number, birthCity?: string, birthDepartment?: string, birthCountry?: string, birthGeoPoint?: GeoPoint, deathDate?: string|number, deathCity?: string, deathDepartment?: string, deathCountry?: string, deathGeoPoint?: GeoPoint, deathAge?: string|number, scroll?: string, scrollId?: string, size?: number, page?: number, fuzzy?: string, sort?: string|Sort[], block?: Block, dateFormat?: any, metadata?: any) {
     this.size = size ? size : 20;
     this.page = page ? page : 1;
     this.scroll = scroll ? scroll : '';
     this.scrollId = scrollId ? scrollId : '';
     this.sort = sort ? sortWithQuery(sort) : {value: [{score: 'desc'}]}
     this.block = block;
+    this.dateFormat = dateFormat;
 
     this.fullText = fullTextWithQuery(q, fuzzy);
     this.name = nameWithQuery({

--- a/backend/src/score.ts
+++ b/backend/src/score.ts
@@ -22,7 +22,7 @@ const uncertainDateScore = 0.7;
 const datePenalty = 3
 
 const minLocationScore = 0.2;
-const minDepScore = 0.6;
+const minDepScore = 0.8;
 const minNotFrCityScore = 0.4;
 
 const boostSoundex = 1.5;
@@ -312,7 +312,9 @@ const scoreLocation = (locA: Location, locB: Location): any => {
         }
     }
     if (locA.departmentCode && locB.departmentCode) {
-        score.department = (locA.departmentCode === locB.departmentCode) ? 1 : minDepScore;
+        if (locB.country && (scoreCountry('FRANCE', locB.country as string|string[]) === 1)) {
+            score.department = (locA.departmentCode === locB.departmentCode) ? 1 : minDepScore;
+        }
     }
     if (locA.country && locB.country) {
         score.country = scoreCountry(locA.country, tokenize(locB.country as string) as string|string[]);

--- a/backend/src/score.ts
+++ b/backend/src/score.ts
@@ -138,7 +138,7 @@ export class ScoreResult {
       this.date = scoreDate(request.birthDate, result.birth.date);
     }
     if (request.firstName || request.lastName) {
-      if (pruneScore < scoreReduce(this)) {
+      if (pruneScore < scoreReduce(this) || !this.date) {
         this.name = scoreName({first: request.firstName, last: request.lastName}, result.name);
       } else {
         this.score = 0

--- a/backend/src/tsoa2.ts
+++ b/backend/src/tsoa2.ts
@@ -1,0 +1,25 @@
+import { generateRoutes, generateSwaggerSpec, RoutesConfig, SwaggerConfig } from 'tsoa';
+
+(async () => {
+  const swaggerOptions: SwaggerConfig = {
+    basePath: '/deces/api/v1',
+    host: `${process.env.API_URL}`,
+    entryFile: './src/index.ts',
+    specVersion: 2,
+    specMerging: 'immediate',
+    outputDirectory: './src/api2',
+    noImplicitAdditionalProperties: "silently-remove-extras",
+    controllerPathGlobs: ['./src/controllers/**/*controller.ts'],
+  };
+
+  const routeOptions: RoutesConfig = {
+    basePath: '/deces/api/v1',
+    entryFile: './src/index.ts',
+    routesDir: './src/routes',
+    middleware: 'express'
+  };
+
+  await generateSwaggerSpec(swaggerOptions, routeOptions);
+
+  await generateRoutes(routeOptions, swaggerOptions);
+})();


### PR DESCRIPTION
* Return birth city code (in french INSEE code), which closes #77 
* Send 400 http code error when job fails, which closes #78
* Catch error when there is no birthDate in bulk mode, which closes #79 
   * Results should be taken carefully when there is no birthdate date because there are a lot of homonyms
* Enable dateFormat as an input parameter for bulk requests, which partially solves #76 
  * One can use `-F "dateFormat=YYYY-MM-DD" ` to parse birthdate date in bulk mode
  * [ ] There is still a need to treat birth and death dateFormat separately.
* A bonus: 🌟 Add swagger version 2.0 for legacy utilization.

