### PR TITLE
🏷 Improve documentation for aggregation route

### DIFF
--- a/backend/src/controllers/aggregation.controller.ts
+++ b/backend/src/controllers/aggregation.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Post, Body, Route, Query, Tags, Header, Request } from
 import express from 'express';
 import { runRequest } from '../runRequest';
 import { buildRequest } from '../buildRequest';
-import { RequestInput, RequestBody } from '../models/requestInput';
+import { RequestInput, RequestBody, AggsInputParams } from '../models/requestInput';
 import { ResultAgg } from '../models/result';
 import { StrAndNumber } from '../models/entities';
 
@@ -55,7 +55,7 @@ export class AggregationController extends Controller {
     @Query() deathCountry?: string,
     @Query() deathAge?: StrAndNumber,
     @Query() fuzzy?: 'true'|'false',
-    @Query() aggs?: string,
+    @Query() aggs?: AggsInputParams[],
     @Query() aggsSize?: number,
     @Header('Accept') accept?: string
   ): Promise<ResultAgg> {

--- a/backend/src/models/requestInput.ts
+++ b/backend/src/models/requestInput.ts
@@ -30,6 +30,8 @@ export interface Block {
   should?: boolean
 }
 
+export type AggsInputParams = 'firstName'|'lastName'|'birthDate'|'birthCity'|'birthDepartment'|'birthCountry'|'deathDate'|'deathCity'|'deathDepartment'|'deathCountry'|'deathAge'|'sex';
+
 /**
  * These are all the query parameters
  * @tsoaModel
@@ -148,7 +150,7 @@ export interface RequestBody {
  /**
   * Champs à aggréger
   */
- aggs?: string[];
+ aggs?: AggsInputParams[];
   /**
   * Nombre de clé max d'aggrégation
   */

--- a/backend/src/server.spec.ts
+++ b/backend/src/server.spec.ts
@@ -591,7 +591,7 @@ describe('server.ts - Express application', () => {
   })
 
   const harryRequest = (fieldName: string) => {
-    return {deathDate: 2020, firstName: 'Harry', aggs: `["${fieldName}"]`}
+    return {deathDate: 2020, firstName: 'Harry', aggs: fieldName}
   }
 
   const fixtureAggregations = [
@@ -618,7 +618,7 @@ describe('server.ts - Express application', () => {
             expect(rowCount).to.eql(total);
           });
       }},
-    {params: {deathDate: 2020, sex: 'M', aggs: `["birthDate"]`}, accept: 'text/csv', fieldName: 'birthDate',
+    {params: {deathDate: 2020, sex: 'M', aggs: "birthDate"}, accept: 'text/csv', fieldName: 'birthDate',
       testFunc: (res: any) => {
         expect(res).to.have.status(200);
         parseString(res.text, { headers: true, delimiter: ','})
@@ -632,7 +632,7 @@ describe('server.ts - Express application', () => {
           });
       }
     },
-    {params: {deathDate: 2020, sex: 'M', aggs: `["birthDate"]`}, accept: 'application/json', fieldName: 'birthDate',
+    {params: {deathDate: 2020, sex: 'M', aggs: "birthDate"}, accept: 'application/json', fieldName: 'birthDate',
       testFunc: (res: any) => {
         expect(res).to.have.status(200);
         expect(res.body.response.aggregations.length).to.eql(res.body.response.cardinality.birthDate);


### PR DESCRIPTION
* Static typing allows to define the aggregation parameters specifically and tsoa library traduces this into swagger api documentation like this: 

![image](https://user-images.githubusercontent.com/18708179/110439799-e96a5e00-8085-11eb-9d42-45fe291f2768.png)

* The get route now accepts request like `http://localhost:8084/deces/api/v1/agg?aggs=firstName&aggs=deathAge&aggs=birthDate&firstName=pierre&aggs=birthDepartment`, so there are multiple `aggs` parameters for aggregation.