### PR TITLE
Supprimer authentification pour route get

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -1,5 +1,5 @@
 import * as jwt from "jsonwebtoken";
-import { Controller, Get, Post, Route, Tags, Body, Query } from 'tsoa';
+import {Body, Controller, Post, Route, Tags} from 'tsoa';
 
 /**
  * @swagger
@@ -28,24 +28,6 @@ export class AuthController extends Controller {
     }
   }
 
-  /**
-   * Authentification endpoint
-   * @summary Route d'authentification
-   * @param password User password
-   */
-  @Tags('Auth')
-  @Get('')
-  public authentificationGet(
-    @Query() password: string,
-  ): AccessToken {
-    if (password === process.env.BACKEND_TOKEN_PASSWORD) {
-      const accessToken = jwt.sign({password, scopes: ['admin']}, process.env.BACKEND_TOKEN_KEY, { expiresIn: "1d" })
-      return { 'access_token': accessToken }
-    } else {
-      this.setStatus(400);
-      return { msg: "Wrong password" }
-    }
-  }
 }
 
 

--- a/backend/src/server.spec.ts
+++ b/backend/src/server.spec.ts
@@ -43,7 +43,8 @@ describe('server.ts - Express application', () => {
   describe('/queue', () => {
     it('/queue/jobs with good token', async () => {
       const token = await chai.request(app)
-        .get(apiPath(`auth?password=${process.env.BACKEND_TOKEN_PASSWORD}`))
+        .post(apiPath(`auth`))
+        .send({password: process.env.BACKEND_TOKEN_PASSWORD})
       const res = await chai.request(app)
         .get(apiPath('queue/jobs/delayed'))
         .set('Authorization', `Bearer ${token.body.access_token as string}`)
@@ -68,14 +69,7 @@ describe('server.ts - Express application', () => {
   })
 
   describe('/auth', () => {
-    it('get password authentification', async () => {
-      const token = await chai.request(app)
-        .get(apiPath(`auth?password=${process.env.BACKEND_TOKEN_PASSWORD}`))
-      expect(token).to.have.status(200);
-      expect(token.body).to.include.all.keys('access_token');
-    });
-
-    it('post password authentification', async () => {
+    it('good password authentification', async () => {
       const token = await chai.request(app)
         .post(apiPath(`auth`))
         .send({password: process.env.BACKEND_TOKEN_PASSWORD})
@@ -83,9 +77,10 @@ describe('server.ts - Express application', () => {
       expect(token.body).to.include.all.keys('access_token');
     });
 
-    it('good password', async () => {
+    it('wrong password authentification', async () => {
       const res = await chai.request(app)
-        .get(apiPath(`auth?password=wrong_password`))
+        .post(apiPath(`auth`))
+        .send({password: 'wrong_password'})
       expect(res).to.have.status(400);
       expect(res.body.msg).to.include('Wrong password');
     });


### PR DESCRIPTION
Pour éviter de passer un token comme un paramètre de query 