### PR TITLE
🚑 Supprimer date-fns pour parser les dates

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1165,11 +1165,6 @@
       "resolved": "https://registry.npmjs.org/damlev/-/damlev-1.0.0.tgz",
       "integrity": "sha1-vOHsycnaaQ3/0ipT4n5wVEH2skA="
     },
-    "date-fns": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.22.1.tgz",
-      "integrity": "sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg=="
-    },
     "dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,6 @@
     "axios": "^0.21.1",
     "bee-queue": "^1.3.1",
     "damlev": "^1.0.0",
-    "date-fns": "^2.22.1",
     "emailjs": "^3.4.0",
     "express": "^4.17.1",
     "fast-csv": "^4.3.6",

--- a/backend/src/masks.ts
+++ b/backend/src/masks.ts
@@ -51,11 +51,36 @@ export const isDateLimit = (dateRangeString: string): string[] => {
 }
 
 export const dateTransform = (dateString: string|number, dateFormatInput: string, dateFormatOutput?: string): string => {
-  if (!dateString) { return '' }
+  if (!dateString || dateString.toString().trim().length === 0) { return '' }
   if (dateFormatInput === dateFormatOutput) { return dateString.toString() }
-  const inputDate = parse(dateString.toString(), dateFormatInput, new Date());
-  return format(inputDate, dateFormatOutput);
+  // input format
+  let yyyy;
+  const yyyyIdx = dateFormatInput.indexOf("yyyy")
+  if (yyyyIdx > -1) {
+    yyyy = dateString.toString().slice(yyyyIdx, yyyyIdx + 4)
+  }
+  let MM;
+  const MMIdx = dateFormatInput.indexOf("MM")
+  if (MMIdx > -1) {
+    MM = dateString.toString().slice(MMIdx, MMIdx + 2)
+  }
+  let dd;
+  const ddIdx = dateFormatInput.indexOf("dd")
+  if (ddIdx > -1) {
+    dd = dateString.toString().slice(ddIdx, ddIdx + 2)
+  }
 
+  // output format
+  if (dateFormatOutput.indexOf("yyyy") > -1) {
+    dateFormatOutput = dateFormatOutput.replace("yyyy", yyyy)
+  }
+  if (dateFormatOutput.indexOf("MM") > -1) {
+    dateFormatOutput = dateFormatOutput.replace("MM", MM)
+  }
+  if (dateFormatOutput.indexOf("dd") > -1) {
+    dateFormatOutput = dateFormatOutput.replace("dd", dd)
+  }
+  return dateFormatOutput
 }
 
 export const dateTransformMask = (dateString: string|number): string => {

--- a/backend/src/masks.ts
+++ b/backend/src/masks.ts
@@ -1,6 +1,4 @@
 import { Sort } from './models/entities';
-import format from 'date-fns/format';
-import parse from 'date-fns/parse';
 
 export const ageValidationMask = (ageString: string): boolean => {
     return /^(|[0-9]|[1-9]([0-9]|[0-3][0-9]))$/.test(ageString);

--- a/backend/src/processStream.ts
+++ b/backend/src/processStream.ts
@@ -19,8 +19,8 @@ import timer from './timer';
 
 const timerRunBulkRequest = timer(runBulkRequest, 'runBulkRequest', 1);
 
-export const validFields: string[] = ['q', 'firstName', 'lastName', 'legalName', 'sex', 'birthDate', 'birthCity', 'birthLocationCode', 'birthDepartment', 'birthCountry',
-'birthGeoPoint', 'deathDate', 'deathCity', 'deathLocationCode', 'deathDepartment', 'deathCountry', 'deathGeoPoint', 'deathAge', 'lastSeenAliveDate', 'source',
+export const validFields: string[] = ['q', 'firstName', 'lastName', 'legalName', 'sex', 'birthDate', 'birthCity', 'birthLocationCode', 'birthPostalCode', 'birthDepartment', 'birthCountry',
+'birthGeoPoint', 'deathDate', 'deathCity', 'deathLocationCode', 'deathPostalCode', 'deathDepartment', 'deathCountry', 'deathGeoPoint', 'deathAge', 'lastSeenAliveDate', 'source',
 'size', 'fuzzy', 'block'];
 
 const log = (json:any) => {
@@ -642,6 +642,7 @@ export const resultsHeader = [
   {label: 'birth.date', labelFr: 'date_naissance', id: 'birthDate'},
   {label: 'birth.location.city', labelFr: 'commune_naissance', id: 'birthCity'},
   {label: 'birth.location.code', labelFr: 'code_INSEE_naissance', id: 'birthLocationCode'},
+  {label: 'birth.location.codePostal', labelFr: 'code_postal_naissance', id: 'birthPostalCode'},
   {label: 'birth.location.departmentCode', labelFr: 'département_naissance', id: 'birthDepartment'},
   {label: 'birth.location.country', labelFr: 'pays_naissance', id: 'birthCountry'},
   {label: 'birth.location.countryCode', labelFr: 'pays_ISO_naissance'},
@@ -652,6 +653,7 @@ export const resultsHeader = [
   {label: 'death.date', id: 'deathDate', labelFr: 'date_décès'},
   {label: 'death.location.city', id: 'deathCity', labelFr: 'commune_décès'},
   {label: 'death.location.code', labelFr: 'code_INSEE_décès', id: 'deathLocationCode'},
+  {label: 'death.location.codePostal', labelFr: 'code_postal_décès', id: 'deathPostalCode'},
   {label: 'death.location.departmentCode', id: 'deathDepartment', labelFr: 'département_décès'},
   {label: 'death.location.country', labelFr: 'pays_décès', id: 'deathCountry'},
   {label: 'death.location.countryCode', labelFr: 'pays_ISO_décès'},


### PR DESCRIPTION
*date-fns* est plus rigoureux que *moment.js* donc il permet pas de parser les dates comme `00/00/1957` avec un format `dd/MM/yyyy`
Le besoin du parsing étant minimal on peut remplacer date-fns par des regex.
Ce PR peut diminuer les dépendances et améliorer les performances.