### PR TITLE
🎨 Accept alternatives date format parameters

### DIFF
--- a/backend/src/masks.ts
+++ b/backend/src/masks.ts
@@ -53,31 +53,53 @@ export const dateTransform = (dateString: string|number, dateFormatInput: string
   if (dateFormatInput === dateFormatOutput) { return dateString.toString() }
   // input format
   let yyyy;
-  const yyyyIdx = dateFormatInput.indexOf("yyyy")
+  let yyyyIdx = dateFormatInput.indexOf("yyyy")
   if (yyyyIdx > -1) {
     yyyy = dateString.toString().slice(yyyyIdx, yyyyIdx + 4)
+  } else {
+    yyyyIdx = dateFormatInput.indexOf("YYYY")
+    if (yyyyIdx > -1) {
+      yyyy = dateString.toString().slice(yyyyIdx, yyyyIdx + 4)
+    }
   }
   let MM;
-  const MMIdx = dateFormatInput.indexOf("MM")
+  let MMIdx = dateFormatInput.indexOf("MM")
   if (MMIdx > -1) {
     MM = dateString.toString().slice(MMIdx, MMIdx + 2)
+  } else {
+    MMIdx = dateFormatInput.indexOf("mm")
+    if (MMIdx > -1) {
+      MM = dateString.toString().slice(MMIdx, MMIdx + 2)
+    }
   }
   let dd;
-  const ddIdx = dateFormatInput.indexOf("dd")
+  let ddIdx = dateFormatInput.indexOf("dd")
   if (ddIdx > -1) {
     dd = dateString.toString().slice(ddIdx, ddIdx + 2)
+  } else {
+    ddIdx = dateFormatInput.indexOf("DD")
+    if (ddIdx > -1) {
+      dd = dateString.toString().slice(ddIdx, ddIdx + 2)
+    }
   }
 
   // output format
-  if (dateFormatOutput.indexOf("yyyy") > -1) {
+  if (yyyyIdx > -1) {
     dateFormatOutput = dateFormatOutput.replace("yyyy", yyyy)
+    dateFormatOutput = dateFormatOutput.replace("YYYY", yyyy)
   }
-  if (dateFormatOutput.indexOf("MM") > -1) {
+  if (MMIdx > -1) {
     dateFormatOutput = dateFormatOutput.replace("MM", MM)
+    dateFormatOutput = dateFormatOutput.replace("mm", MM)
   }
-  if (dateFormatOutput.indexOf("dd") > -1) {
+  if (ddIdx > -1) {
     dateFormatOutput = dateFormatOutput.replace("dd", dd)
+    dateFormatOutput = dateFormatOutput.replace("DD", dd)
   }
+  // remove default output format alphanumerical characters
+  dateFormatOutput = dateFormatOutput.replace("dd/", "00/")
+  dateFormatOutput = dateFormatOutput.replace("MM/", "00/")
+  dateFormatOutput = dateFormatOutput.replace("yyyy/", "0000/")
   return dateFormatOutput
 }
 

--- a/backend/src/processStream.spec.ts
+++ b/backend/src/processStream.spec.ts
@@ -79,4 +79,31 @@ describe('processStream.ts - Process chunk', () => {
     expect(result[0][0].scores.name.last).to.above(0.65)
   });
 
+  it('Wrong date format: DD/MM/YYYY instead of dd/MM/yyyy', async () => {
+    const result = await processChunk(
+      [{firstName: 'jean', lastName: 'pierre', birthDate: '04/08/1933'}],
+      1,
+      {
+        dateFormat: 'DD/MM/YYYY'
+      }
+    )
+    expect(result.length).to.equal(1)
+    expect(result[0][0].name.first).to.contain('Jean')
+    expect(result[0][0].name.last).to.equal('Pierre')
+  });
+
+  it('Wrong date format: missing day dd', async () => {
+    const result = await processChunk(
+      [{firstName: 'jean', lastName: 'pierre', birthDate: '08/1933'}],
+      1,
+      {
+        dateFormat: 'MM/YYYY',
+        pruneScore: 0.01
+      }
+    )
+    expect(result.length).to.equal(1)
+    expect(result[0][0].name.first).to.contain('Jean')
+    expect(result[0][0].name.last).to.equal('Pierre')
+  });
+
 });


### PR DESCRIPTION
Actuellement l'API planté avec un mauvais format de date.
Ce PR propose d'accepter les formats yyyy, MM et dd en majuscule et minuscule.
On peut accepter le format de dates un info manquante comme le jour ou le mois. 
Fix #249 