### PR TITLE
👷 Upload docker image to artifacts in github actions

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -28,7 +28,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - name: 🐋 Save docker image
         run: make docker-save
-      - name: Upload docker image
+      - name: ⬆ Upload docker image
         uses: actions/upload-artifact@v2
         with:
           name: deces-backend
@@ -40,11 +40,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Download docker image
+      - name: ⬇ Download docker image
         uses: actions/download-artifact@v2
         with:
           name: deces-backend
-      - name: Build the dev docker image
+      - name: 🐳 Load docker image
         run: make docker-load
       - name: Make deploy local
         run: make deploy-dependencies backend-perf-clinic
@@ -55,7 +55,10 @@ jobs:
       - name: ⚗ Run artillery tests
         run: |
           docker cp backend/tests/clients_test.csv `docker ps -l --format "{{.Names}}" --filter name=deces-backend`:/deces-backend/tests/clients_test.csv
-          make test-perf-v1 backend-perf-clinic-stop
+          make test-perf-v1
+      - name: ⚕ Save doctor.js results
+        run: |
+          make backend-perf-clinic-stop
       - name: 📦 Upload results as job artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -26,6 +26,13 @@ jobs:
         run: make docker-push GIT_BRANCH="${GITHUB_REF#refs/heads/}"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: 🐋 Save docker image
+        run: make docker-save
+      - name: Upload docker image
+        uses: actions/upload-artifact@v2
+        with:
+          name: deces-backend
+          path: deces-backend.tar
   bulk:
     name: ✅ Perfs test with artillery.io
     runs-on: ubuntu-latest
@@ -33,8 +40,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+      - name: Download docker image
+        uses: actions/download-artifact@v2
+        with:
+          name: deces-backend
       - name: Build the dev docker image
-        run: make backend-build-all
+        run: make docker-load
       - name: Make deploy local
         run: make deploy-dependencies backend-perf-clinic
         env:

--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,7 @@ backend-perf-clinic-stop:
 	@docker exec `docker ps -l --format "{{.Names}}" --filter name=deces-backend` /bin/bash -c "kill -INT \`pidof node\`"
 	@docker logs --tail 5 `docker ps -l --format "{{.Names}}" --filter name=deces-backend`
 	@docker restart `docker ps -l --format "{{.Names}}" --filter name=deces-backend`
+	@ls ${BACKEND}/clinic/*
 	@docker exec `docker ps -l --format "{{.Names}}" --filter name=deces-backend` /bin/bash -c "/${APP}/node_modules/.bin/clinic doctor --no-insight --visualize-only clinic/\`ls /${APP}/clinic/ |head -n 1 \`"
 
 # development mode

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,11 @@ docker-check:
 		|| (echo no previous build found for ${DOCKER_USERNAME}/${DC_IMAGE_NAME}:${APP_VERSION} && exit 1);\
 	fi;
 
+docker-save:
+	@docker save -o deces-backend.tar ${DOCKER_USERNAME}/deces-backend:${APP_VERSION}
+
+docker-load:
+	@docker load -i deces-backend.tar
 
 #############
 #  Backend  #


### PR DESCRIPTION
Passing docker image through jobs avoid building the image each time. It reduces between 2 or 3 minutes the artillery job tests.