### PR TITLE
🐛 Catch error for date format parsing

### DIFF
--- a/backend/src/buildRequest.ts
+++ b/backend/src/buildRequest.ts
@@ -28,7 +28,7 @@ const buildAdaptativeBlockMatch = (searchInput: RequestInput) => {
     if (searchInput.name.value.legal) {
       queryShould = [...queryShould, matchQuery('NOM', searchInput.name.value.legal as string, false, false)]
     }
-    if (searchInput.birthDate && searchInput.birthDate.value) {
+    if (searchInput.birthDate && searchInput.birthDate.value && (typeof(searchInput.birthDate.mask.transform(searchInput.birthDate.value, searchInput.dateFormat)) === 'string')) {
       if (isDateRange(searchInput.birthDate.value as string) || isDateLimit(searchInput.birthDate.value as string)) {
         queryMust = [
           ...queryMust,

--- a/backend/src/buildRequest.ts
+++ b/backend/src/buildRequest.ts
@@ -1,8 +1,18 @@
+import loggerStream from './logger';
 import { Sort } from './models/entities';
 import { RequestInput } from './models/requestInput';
 import { BodyResponse, ScrolledResponse } from './models/body';
 import { fuzzyTermQuery, matchQuery, prefixQuery } from './queries';
 import { isDateRange, isDateLimit, sortTransformationMask } from './masks';
+
+const log = (json:any) => {
+  loggerStream.write(JSON.stringify({
+    "backend": {
+      "server-date": new Date(Date.now()).toISOString(),
+      ...json
+    }
+  }));
+}
 
 const buildMatch = (requestInput: RequestInput) => {
   if (requestInput.block) {
@@ -52,6 +62,11 @@ const buildAdaptativeBlockMatch = (searchInput: RequestInput) => {
           matchQuery(searchInput.birthDate.field as string, searchInput.birthDate.mask.transform(searchInput.birthDate.value, searchInput.dateFormat) as string, false, false),
         ];
       }
+    } else {
+      log({
+        error: "Bad birthDate parsing",
+        ...searchInput.birthDate && {birthDate: searchInput.birthDate.value}
+      });
     }
     if (searchInput.deathDate && searchInput.deathDate.value) {
       if (isDateRange(searchInput.deathDate.value as string) || isDateLimit(searchInput.deathDate.value as string)) {

--- a/backend/src/processStream.spec.ts
+++ b/backend/src/processStream.spec.ts
@@ -106,4 +106,21 @@ describe('processStream.ts - Process chunk', () => {
     expect(result[0][0].name.last).to.equal('Pierre')
   });
 
+  it('Wrong date format: mixed formats', async () => {
+    const result = await processChunk(
+      [
+        {firstName: 'jean', lastName: 'pierre', birthDate: '04/08/1933'},
+        {firstName: 'jean', lastName: 'pierre', birthDate: '08-1933'}
+      ],
+      1,
+      {
+        dateFormat: 'DD/MM/YYYY',
+        pruneScore: 0.01
+      }
+    )
+    expect(result.length).to.equal(2)
+    expect(result[0][0].name.first).to.contain('Jean')
+    expect(result[0][0].name.last).to.equal('Pierre')
+  });
+
 });

--- a/backend/src/processStream.ts
+++ b/backend/src/processStream.ts
@@ -181,7 +181,12 @@ export const processCsv =  async (job: Job<any>, jobFile: JobInput): Promise<any
         stopJobReason.push({id: job.id, msg: e.toString()})
       })
       .pipe(processStream)
-      .on('error', (e: any) => log({matchingProcessingError: e.toString(), jobId}))
+      .on('error', (e: any) => {
+        log({matchingProcessingError: e.toString(), jobId})
+        readStream.close()
+        stopJob.push(job.id);
+        stopJobReason.push({id: job.id, msg: e.toString()})
+      })
       .pipe(jsonStringStream)
       .on('error', (e: any) => log({stringifyProcessingError: e.toString(), jobId}))
       .pipe(gzipStream)

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -110,10 +110,13 @@ app.use((
   }
   if (err instanceof Error) {
     log({
-      error: err.toString()
+      ...err.stack && {error: err.stack}
     });
     return res.status(500).json({
-      message: err.toString(),
+      message: {
+        ...err.message && {error: err.message},
+        ...err.stack && {stacktrace: err.stack}
+      }
     });
   }
   next();


### PR DESCRIPTION
Ça peut arriver d'avoir des dates avec un format diffèrent à celui du format de date déclaré.
Ce type de problème doit pas arrêter le traitement mais plutôt d'exclure l'utilisation de la date pour le rapprochement.
Ce type d'erreur va être quand même rajouté aux log de l'application.