### PR TITLE
✨ Add geopoint query parameter for search get method

### DIFF
--- a/backend/src/controllers/search.controller.ts
+++ b/backend/src/controllers/search.controller.ts
@@ -72,12 +72,14 @@ export class SearchController extends Controller {
     @Query() birthPostalCode?: string,
     @Query() birthDepartment?: StrAndNumber,
     @Query() birthCountry?: string,
+    @Query() birthGeoPoint?: string,
     @Query() deathDate?: StrAndNumber,
     @Query() deathCity?: string,
     @Query() deathLocationCode?: string,
     @Query() deathPostalCode?: string,
     @Query() deathDepartment?: StrAndNumber,
     @Query() deathCountry?: string,
+    @Query() deathGeoPoint?: string,
     @Query() deathAge?: StrAndNumber,
     @Query() lastSeenAliveDate?: string,
     @Query() source?: string,
@@ -88,13 +90,13 @@ export class SearchController extends Controller {
     @Query() fuzzy?: 'true'|'false',
     @Query() sort?: string
   ): Promise<Result> {
-    if (q || firstName || lastName || legalName || sex || birthDate || birthCity || birthLocationCode || birthPostalCode || birthDepartment || birthCountry || deathDate || deathCity || deathLocationCode || deathPostalCode || deathDepartment || deathCountry || deathAge || lastSeenAliveDate || source || scroll) {
-      const requestInput = new RequestInput({q, firstName, lastName, legalName, sex, birthDate, birthCity, birthPostalCode, birthLocationCode, birthDepartment, birthCountry, deathDate, deathCity, deathPostalCode, deathLocationCode, deathDepartment, deathCountry, deathAge, lastSeenAliveDate, source, scroll, scrollId, size, page, fuzzy, sort});
+    if (q || firstName || lastName || legalName || sex || birthDate || birthCity || birthLocationCode || birthPostalCode || birthDepartment || birthCountry || birthGeoPoint || deathDate || deathCity || deathLocationCode || deathPostalCode || deathDepartment || deathCountry || deathGeoPoint || deathAge || lastSeenAliveDate || source || scroll) {
+      const requestInput = new RequestInput({q, firstName, lastName, legalName, sex, birthDate, birthCity, birthPostalCode, birthLocationCode, birthDepartment, birthCountry, birthGeoPoint, deathDate, deathCity, deathPostalCode, deathLocationCode, deathDepartment, deathCountry, deathGeoPoint, deathAge, lastSeenAliveDate, source, scroll, scrollId, size, page, fuzzy, sort});
       if (requestInput.errors.length) {
         this.setStatus(400);
         return  { msg: requestInput.errors };
       }
-      if ((firstName || lastName || legalName || sex || birthDate || birthCity || birthLocationCode || birthDepartment || birthCountry || deathDate || deathCity || deathLocationCode || deathDepartment || deathCountry || deathAge) && q) {
+      if ((firstName || lastName || legalName || sex || birthDate || birthCity || birthLocationCode || birthDepartment || birthCountry || birthGeoPoint || deathDate || deathCity || deathLocationCode || deathDepartment || deathCountry || deathGeoPoint || deathAge) && q) {
         this.setStatus(400);
         return  { msg: "error - simple and complex request at the same time" };
       }

--- a/backend/src/controllers/search.controller.ts
+++ b/backend/src/controllers/search.controller.ts
@@ -41,11 +41,13 @@ export class SearchController extends Controller {
    * @param birthLocationCode Code INSEE du lieu de naissance
    * @param birthDepartment Code département du lieu de naissance
    * @param birthCountry Libellé de pays de naissance en clair (pour les personnes nées à l'étranger)
+   * @param birthGeoPoint Coordonnées GPS du point de naissance
    * @param deathDate Date de décès au format\: JJ/MM/AAAA. <br> <li> Pour une date inconnue les valeurs sont 0000 pour AAAA; 00 pour MM et JJ</li>.<br> <li> Une recherche par tranche de date est également possible sous la forme: JJ/MM/AAAA - JJ/MM/AAAA</li>
    * @param deathCity Localité de décès en claire** (pour les personnes nées en France ou dans les DOM/TOM/COM)
    * @param deathLocationCode Code INSEE du lieu de décès
    * @param deathDepartment Code département du lieu de décès
    * @param deathCountry Pays du lieu de décès
+   * @param deathGeoPoint Coordonnées GPS du point de décès
    * @param deathAge Age du décès
    * @param lastSeenAliveDate Dernière fois que la personne était vue en vie
    * @param source Nom du fichier INSEE source

--- a/backend/src/controllers/search.spec.ts
+++ b/backend/src/controllers/search.spec.ts
@@ -36,6 +36,11 @@ describe('search.controller.ts - GET request', () => {
     expect(result.response.persons.map(x => x.birth.location.city)).to.include('Noyon')
   });
 
+  it('Bad GeoPoint in query', async () => {
+    const result = await controller.search(null, null, null, null, null, null, null, null, null, null, null, `{"latitude": 49.6, "longitude": 2.98}`)
+    expect(result.msg[0]).to.include('invalid birthGeoPoint');
+  });
+
 });
 
 describe('search.controller.ts - POST request', () => {

--- a/backend/src/controllers/search.spec.ts
+++ b/backend/src/controllers/search.spec.ts
@@ -21,14 +21,19 @@ describe('search.controller.ts - GET request', () => {
   });
 
   it('Query by lastSeenAliveDate', async () => {
-    const result = await controller.search(null, 'jean', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, '20/01/2020')
+    const result = await controller.search(null, 'jean', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, '20/01/2020')
     expect(result.response.persons.every(x => parseInt(x.death.date, 10) >= 20200120)).to.equal(true);
     expect(result.response.persons.length).to.greaterThan(0);
   });
 
   it('Query by source', async () => {
-    const result = await controller.search(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, '2020-m01')
+    const result = await controller.search(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, '2020-m01')
     expect(result.response.persons.length).to.greaterThan(0);
+  });
+
+  it('Query by GeoPoint', async () => {
+    const result = await controller.search(null, null, null, null, null, null, null, null, null, null, null, `{"latitude": 49.6, "longitude": 2.98, "distance": "10km"}`)
+    expect(result.response.persons.map(x => x.birth.location.city)).to.include('Noyon')
   });
 
 });

--- a/backend/src/fieldsWithQueries.ts
+++ b/backend/src/fieldsWithQueries.ts
@@ -12,7 +12,9 @@ import {
     aggsTransformMask,
     fuzzyValidation,
     fuzzyTransform,
-    sourceValidationMask
+    sourceValidationMask,
+    geoPointValidationMask,
+    geoPointTransformMask
 } from './masks';
 
 import {
@@ -108,8 +110,12 @@ export const birthCountryWithQuery = (value: string, fuzzy: boolean): WithQuery 
     fuzzy: fuzzy ? "auto" : false
 };
 
-export const birthGeoPointWithQuery = (value: GeoPoint): WithQuery => value && {
+export const birthGeoPointWithQuery = (value: GeoPoint|string): WithQuery => value && {
     value,
+    mask: {
+        validation: geoPointValidationMask,
+        transform: geoPointTransformMask
+    },
     field: "GEOPOINT_NAISSANCE",
     query: geoPointQuery,
     fuzzy: false
@@ -172,8 +178,12 @@ export const deathCountryWithQuery = (value: string, fuzzy: boolean): WithQuery 
     fuzzy: fuzzy ? "auto" : false
 };
 
-export const deathGeoPointWithQuery = (value: GeoPoint): WithQuery => value && {
+export const deathGeoPointWithQuery = (value: GeoPoint|string): WithQuery => value && {
     value,
+    mask: {
+        validation: geoPointValidationMask,
+        transform: geoPointTransformMask
+    },
     field: "GEOPOINT_DECES",
     query: geoPointQuery,
     fuzzy: false

--- a/backend/src/masks.ts
+++ b/backend/src/masks.ts
@@ -1,4 +1,4 @@
-import { Sort } from './models/entities';
+import { Sort, GeoPoint } from './models/entities';
 
 export const ageValidationMask = (ageString: string): boolean => {
     return /^(|[0-9]|[1-9]([0-9]|[0-3][0-9]))$/.test(ageString);
@@ -152,6 +152,29 @@ export const sortValidationMask = (sort: string|Sort[]): boolean => {
   }
 }
 
+export const geoPointValidationMask = (geoPoint: string|GeoPoint): boolean => {
+  if (typeof(geoPoint) === 'string') {
+    try {
+      if (Object.values(JSON.parse(geoPoint)).length > 0) {
+        // TODO: add verification for latitude and longitude
+        return true;
+      } else {
+        return false;
+      }
+    } catch (e) {
+      return false;
+    }
+  } else {
+    try {
+      // TODO: add verification for latitude and longitude
+      if (Object.values(geoPoint).length > 0) return true;
+      return false;
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
 export const sortTransformationMask = (sort: string|Sort[]): Sort[] => {
   return (typeof(sort) === 'string') ? Object.values(JSON.parse(sort)) : Object.values(sort)
 }
@@ -186,6 +209,10 @@ export const aggsValidationMask = (aggs: string|string[]): boolean => {
       return false;
     }
   }
+}
+
+export const geoPointTransformMask = (geoPoint: GeoPoint|string): GeoPoint => {
+  return (typeof(geoPoint) === 'string') ? JSON.parse(geoPoint) : geoPoint
 }
 
 export const aggsTransformMask = (aggs: string|string[]): string[] => {

--- a/backend/src/masks.ts
+++ b/backend/src/masks.ts
@@ -156,8 +156,11 @@ export const geoPointValidationMask = (geoPoint: string|GeoPoint): boolean => {
   if (typeof(geoPoint) === 'string') {
     try {
       if (Object.values(JSON.parse(geoPoint)).length > 0) {
-        // TODO: add verification for latitude and longitude
-        return true;
+        if (JSON.parse(geoPoint).latitude && JSON.parse(geoPoint).longitude && JSON.parse(geoPoint).distance) {
+          return true;
+        } else {
+          return false;
+        }
       } else {
         return false;
       }
@@ -166,9 +169,15 @@ export const geoPointValidationMask = (geoPoint: string|GeoPoint): boolean => {
     }
   } else {
     try {
-      // TODO: add verification for latitude and longitude
-      if (Object.values(geoPoint).length > 0) return true;
+      if (Object.values(geoPoint).length > 0) {
+        if (geoPoint.latitude && geoPoint.longitude && geoPoint.distance) {
+          return true;
+        } else {
+          return false;
+        }
+      } else {
       return false;
+      }
     } catch (e) {
       return false;
     }

--- a/backend/src/models/requestInput.ts
+++ b/backend/src/models/requestInput.ts
@@ -180,14 +180,14 @@ interface RequestInputParams {
   birthLocationCode?: string;
   birthDepartment?: string|number;
   birthCountry?: string;
-  birthGeoPoint?: GeoPoint;
+  birthGeoPoint?: GeoPoint|string;
   deathDate?: string|number;
   deathCity?: string;
   deathPostalCode?: string;
   deathLocationCode?: string;
   deathDepartment?: string|number;
   deathCountry?: string;
-  deathGeoPoint?: GeoPoint;
+  deathGeoPoint?: GeoPoint|string;
   deathAge?: string|number;
   lastSeenAliveDate?: string;
   source?: string;

--- a/backend/src/models/requestInput.ts
+++ b/backend/src/models/requestInput.ts
@@ -111,6 +111,9 @@ export interface RequestBody {
   * Libellé de pays de naissance en clair (pour les personnes nées à l'étranger)
   */
  birthCountry?: string;
+ /**
+  * Coordonnées GPS du point de naissance
+  */
  birthGeoPoint?: GeoPoint;
  /**
   * Date de décès au format\: JJ/MM/AAAA. <br> <li> Pour une date inconnue les valeurs sont 0000 pour AAAA; 00 pour MM et JJ</li>.<br> <li> Une recherche par tranche de date est également possible sous la forme: JJ/MM/AAAA - JJ/MM/AAAA</li>
@@ -136,6 +139,9 @@ export interface RequestBody {
   * Pays du lieu de décès
   */
  deathCountry?: string;
+ /**
+  * Coordonnées GPS du point de décès
+ */
  deathGeoPoint?: GeoPoint;
  /**
   * Age du décès


### PR DESCRIPTION
On peut utiliser les coordonnées GPS dans la requête GET, par exemple:

```
https://deces.matchid.io/deces/api/v1/search?birthGeoPoint=%7B%22latitude%22%3A%2049.6%2C%20%22longitude%22%3A%202.98%2C%20%22distance%22%3A%20%2210km%22%7D
```

C'est un peu moche, mais ça rend équivalent les possibilités de la requête GET et POST.