### PR TITLE
✨ Add compare identities using score function

### DIFF
--- a/backend/src/communes.ts
+++ b/backend/src/communes.ts
@@ -77,8 +77,9 @@ try {
       dic[cityNorm(feature.properties.nom) as string] = {
         lat,
         lon,
-        code: feature.properties.insee
-        // TODO: surf_ha dispo to use for ML
+        code: feature.properties.insee,
+        // surface en hectares de la commune.
+        surface: feature.properties.surf_ha
       }});
 } catch(e) {
     // eslint-disable-next-line no-console
@@ -90,5 +91,6 @@ export const communesDict = dic as {
       lat: number;
       lon: number;
       code: string;
+      surface: string;
     };
 };

--- a/backend/src/controllers/search.controller.ts
+++ b/backend/src/controllers/search.controller.ts
@@ -14,6 +14,7 @@ import { format } from '@fast-csv/format';
 import { ScoreResult, personFromRequest } from '../score';
 import { updatedFields } from '../updatedIds';
 import { sendUpdateConfirmation } from '../mail';
+import { dateTransform } from '../masks';
 // import getDataGouvCatalog from '../getDataGouvCatalog';
 
 const writeFileAsync = promisify(writeFile);
@@ -504,7 +505,7 @@ export class SearchController extends Controller {
   @Tags('Simple')
   @Post('/compare')
   public compareIdentitiesPost(@Body() requestBody: PersonCompare): ScoreResult {
-    const result = new ScoreResult(personFromRequest(requestBody.personA), personFromRequest(requestBody.personB))
+    const result = new ScoreResult(personFromRequest(requestBody.personA), personFromRequest(requestBody.personB), requestBody.params)
     return  result;
   }
 

--- a/backend/src/controllers/search.controller.ts
+++ b/backend/src/controllers/search.controller.ts
@@ -8,9 +8,10 @@ import { resultsHeader, jsonPath, prettyString } from '../processStream';
 import { runRequest, runBulkRequest } from '../runRequest';
 import { buildRequest } from '../buildRequest';
 import { RequestInput, RequestBody } from '../models/requestInput';
-import { StrAndNumber, Modification, UpdateRequest, UpdateUserRequest, Review, ReviewsStringified, statusAuthMap } from '../models/entities';
+import { StrAndNumber, Modification, UpdateRequest, UpdateUserRequest, Review, ReviewsStringified, statusAuthMap, PersonCompare } from '../models/entities';
 import { buildResult, buildResultSingle, Result, ErrorResponse } from '../models/result';
 import { format } from '@fast-csv/format';
+import { ScoreResult } from '../score';
 import { updatedFields } from '../updatedIds';
 import { sendUpdateConfirmation } from '../mail';
 // import getDataGouvCatalog from '../getDataGouvCatalog';
@@ -492,6 +493,19 @@ export class SearchController extends Controller {
             resolve(true);
         })
     })
+  }
+
+  /**
+   * Compare identities
+   * @summary Compare identities
+   */
+  @Response<ErrorResponse>('400', 'Bad request')
+  @Response<ScoreResult>('200', 'OK')
+  @Tags('Simple')
+  @Post('/compare')
+  public compareIdentitiesPost(@Body() requestBody: PersonCompare): ScoreResult {
+    const result = new ScoreResult(requestBody.personA, requestBody.personB)
+    return  result;
   }
 
 }

--- a/backend/src/controllers/search.controller.ts
+++ b/backend/src/controllers/search.controller.ts
@@ -11,7 +11,7 @@ import { RequestInput, RequestBody } from '../models/requestInput';
 import { StrAndNumber, Modification, UpdateRequest, UpdateUserRequest, Review, ReviewsStringified, statusAuthMap, PersonCompare } from '../models/entities';
 import { buildResult, buildResultSingle, Result, ErrorResponse } from '../models/result';
 import { format } from '@fast-csv/format';
-import { ScoreResult } from '../score';
+import { ScoreResult, personFromRequest } from '../score';
 import { updatedFields } from '../updatedIds';
 import { sendUpdateConfirmation } from '../mail';
 // import getDataGouvCatalog from '../getDataGouvCatalog';
@@ -504,7 +504,7 @@ export class SearchController extends Controller {
   @Tags('Simple')
   @Post('/compare')
   public compareIdentitiesPost(@Body() requestBody: PersonCompare): ScoreResult {
-    const result = new ScoreResult(requestBody.personA, requestBody.personB)
+    const result = new ScoreResult(personFromRequest(requestBody.personA), personFromRequest(requestBody.personB))
     return  result;
   }
 

--- a/backend/src/controllers/search.spec.ts
+++ b/backend/src/controllers/search.spec.ts
@@ -105,11 +105,12 @@ describe('search.controller.ts - POST id', () => {
 
 describe('search.controller.ts - POST compare', () => {
   const controller = new SearchController()
-  it('compare', () => {
+
+  it('compare name and birth date', () => {
     const body: PersonCompare = {
       personA: {
-          firstName: 'georges',
-          lastName: 'pompidous',
+        firstName: 'georges',
+        lastName: 'pompidous',
         birthDate: "19691101"
       },
       personB: {
@@ -122,5 +123,33 @@ describe('search.controller.ts - POST compare', () => {
     const res = controller.compareIdentitiesPost(body)
     expect(res).to.contain.all.keys(['score', 'birthDate', 'birthLocation', 'name'])
     expect(res.score).to.equal(0.73);
+  });
+
+  it('compare with Geopoints', () => {
+    const body: PersonCompare = {
+      personA: {
+        firstName: 'georges',
+        lastName: 'pompidous',
+        birthCountry: "France",
+        birthGeoPoint: {
+          latitude: 48.847759,
+          longitude: 2.439497,
+          distance: "10km"
+        }
+      },
+      personB: {
+        firstName: "Georges",
+        lastName: "Pompidou",
+        birthCountry: "France",
+        birthGeoPoint: {
+          latitude: 48.847759,
+          longitude: 2.339497,
+          distance: "10km"
+        }
+      }
+    }
+    const res = controller.compareIdentitiesPost(body)
+    expect(res).to.contain.all.keys(['score', 'birthLocation', 'name'])
+    expect(res.score).to.equal(0.6);
   });
 });

--- a/backend/src/controllers/search.spec.ts
+++ b/backend/src/controllers/search.spec.ts
@@ -1,4 +1,5 @@
 import { SearchController } from './search.controller';
+import { PersonCompare } from '../models/entities';
 import express from 'express';
 import { expect } from 'chai';
 import 'mocha';
@@ -99,5 +100,27 @@ describe('search.controller.ts - POST id', () => {
     } as express.Request
     const res = await controller.updateId('POgzt_2CZT2o', body, req)
     expect(res.msg).to.equal('Update stored');
+  });
+});
+
+describe('search.controller.ts - POST compare', () => {
+  const controller = new SearchController()
+  it('compare', () => {
+    const body: PersonCompare = {
+      personA: {
+          firstName: 'georges',
+          lastName: 'pompidous',
+        birthDate: "19691101"
+      },
+      personB: {
+        firstName: "Georges",
+        lastName: "Pompidou",
+        sex: "M",
+        birthDate: "19691101",
+      }
+    }
+    const res = controller.compareIdentitiesPost(body)
+    expect(res).to.contain.all.keys(['score', 'birthDate', 'birthLocation', 'name'])
+    expect(res.score).to.equal(0.73);
   });
 });

--- a/backend/src/models/entities.ts
+++ b/backend/src/models/entities.ts
@@ -5,8 +5,8 @@ export interface Sort {
 }
 
 export interface Name {
-    first: string|string[]|RequestField;
-    last: string|string[]|RequestField;
+    first?: string|string[]|RequestField;
+    last?: string|string[]|RequestField;
     legal?: string|string[]|RequestField;
   };
 
@@ -133,22 +133,22 @@ export interface Modification {
 };
 
 export interface Person {
-    score: number;
-    source: string;
-    sourceLine: number;
-    id: string;
-    name: Name;
-    sex: 'M'|'F';
-    scores: ScoreResult;
-    birth: {
-      date: string;
-      location: Location;
+    score?: number;
+    source?: string;
+    sourceLine?: number;
+    id?: string;
+    name?: Name;
+    sex?: 'M'|'F';
+    scores?: ScoreResult;
+    birth?: {
+      date?: string;
+      location?: Location;
     };
-    death: {
+    death?: {
       date: string;
-      certificateId: string;
-      age: number;
-      location: Location;
+      certificateId?: string;
+      age?: number;
+      location?: Location;
     };
     links?: {
       label?: string;

--- a/backend/src/models/entities.ts
+++ b/backend/src/models/entities.ts
@@ -1,4 +1,5 @@
 import { ScoreResult } from '../score';
+import { RequestBody } from './requestInput';
 
 export interface Sort {
  [key: string]: 'asc'|'desc';
@@ -160,8 +161,8 @@ export interface Person {
   };
 
 export interface PersonCompare {
-  personA: Person;
-  personB: Person;
+  personA: RequestBody;
+  personB: RequestBody;
 };
 
 export interface ScoreParams {

--- a/backend/src/models/entities.ts
+++ b/backend/src/models/entities.ts
@@ -163,10 +163,13 @@ export interface Person {
 export interface PersonCompare {
   personA: RequestBody;
   personB: RequestBody;
+  params?: ScoreParams;
 };
 
 export interface ScoreParams {
-  dateFormat?: string;
+  dateFormatA?: string;
+  dateFormatB?: string;
+  explain?: boolean;
   pruneScore?: number;
   candidateNumber?: number;
 };

--- a/backend/src/models/entities.ts
+++ b/backend/src/models/entities.ts
@@ -159,6 +159,11 @@ export interface Person {
     modifications?: Modification[];
   };
 
+export interface PersonCompare {
+  personA: Person;
+  personB: Person;
+};
+
 export interface ScoreParams {
   dateFormat?: string;
   pruneScore?: number;

--- a/backend/src/models/result.ts
+++ b/backend/src/models/result.ts
@@ -215,7 +215,7 @@ export const buildResult = (result: ResultRawES, requestInput: RequestInput): Re
     }
   })
   let filteredResults = result.hits.hits.map(buildResultSingle)
-  scoreResults(filteredRequest, filteredResults, {dateFormat: filteredRequest.dateFormat})
+  scoreResults(filteredRequest, filteredResults, {dateFormatA: filteredRequest.dateFormat})
   if (requestInput.sort && Object.values(requestInput.sort.value).map(x => Object.keys(x))[0].includes('score')) {
     if (Object.values(requestInput.sort.value).find(x => x.score).score === 'asc') {
       filteredResults = filteredResults.sort((a: Person, b: Person) => a.score - b.score)

--- a/backend/src/models/result.ts
+++ b/backend/src/models/result.ts
@@ -297,8 +297,8 @@ export const buildResultSingle = (item: ResultRawHit): Person => {
     result.modifications = updatedData.map((u: any) => {
       const update: any = {...u};
       // WIP quick n dirty anonymization
-      const author: string = u.author as string;
-      update.author = author.substring(0,2)
+      const { author } = u;
+      update.author = author && author.substring(0,2)
         + '...' + author.replace(/@.*/,'').substring(author.replace(/@.*/,'').length-2)
         + '@' + author.replace(/.*@/,'');
       return update;

--- a/backend/src/processStream.spec.ts
+++ b/backend/src/processStream.spec.ts
@@ -8,7 +8,7 @@ describe('processStream.ts - Process chunk', () => {
       [{firstName: 'jean', lastName: 'pierre', birthDate: '04/08/1933'}, {firstName: 'georges', lastName: 'michel', birthDate: '12/03/1939'}],
       5,
       {
-        dateFormat: 'dd/MM/yyyy',
+        dateFormatA: 'dd/MM/yyyy',
       }
     )
     expect(result.length).to.equal(2)
@@ -21,7 +21,7 @@ describe('processStream.ts - Process chunk', () => {
       [{firstName: 'jean', lastName: 'petit'}, {firstName: 'georges', lastName: 'michel'}],
       10,
       {
-        dateFormat: 'dd/MM/yyyy',
+        dateFormatA: 'dd/MM/yyyy',
       },
     )
     expect(result[0].length).to.above(2)
@@ -37,7 +37,7 @@ describe('processStream.ts - Process chunk', () => {
       [{firstName: 'jean', lastName: 'petit'}],
       5,
       {
-        dateFormat: 'dd/MM/yyyy',
+        dateFormatA: 'dd/MM/yyyy',
         pruneScore: 0.5
       },
     )
@@ -45,7 +45,7 @@ describe('processStream.ts - Process chunk', () => {
       [{firstName: 'jean', lastName: 'petit'}],
       5,
       {
-        dateFormat: 'dd/MM/yyyy',
+        dateFormatA: 'dd/MM/yyyy',
         pruneScore: 0.1
       },
     )
@@ -57,7 +57,7 @@ describe('processStream.ts - Process chunk', () => {
       [{firstName: 'jean', lastName: 'pierre', birthDate: '1933-08-04'}, {firstName: 'georges', lastName: 'michel', birthDate: '1939-03-12'}],
       1,
       {
-        dateFormat: 'yyyy-MM-dd'
+        dateFormatA: 'yyyy-MM-dd'
       }
     )
     expect(result.length).to.equal(2)
@@ -70,7 +70,7 @@ describe('processStream.ts - Process chunk', () => {
       [{firstName: 'jeanne', lastName: 'michou', sex: 'F', legalName: 'marie'}],
       1,
       {
-        dateFormat: 'yyyy-MM-dd'
+        dateFormatA: 'yyyy-MM-dd'
       }
     )
     expect(result.length).to.equal(1)
@@ -84,7 +84,7 @@ describe('processStream.ts - Process chunk', () => {
       [{firstName: 'jean', lastName: 'pierre', birthDate: '04/08/1933'}],
       1,
       {
-        dateFormat: 'DD/MM/YYYY'
+        dateFormatA: 'DD/MM/YYYY'
       }
     )
     expect(result.length).to.equal(1)
@@ -97,7 +97,7 @@ describe('processStream.ts - Process chunk', () => {
       [{firstName: 'jean', lastName: 'pierre', birthDate: '08/1933'}],
       1,
       {
-        dateFormat: 'MM/YYYY',
+        dateFormatA: 'MM/YYYY',
         pruneScore: 0.01
       }
     )
@@ -114,7 +114,7 @@ describe('processStream.ts - Process chunk', () => {
       ],
       1,
       {
-        dateFormat: 'DD/MM/YYYY',
+        dateFormatA: 'DD/MM/YYYY',
         pruneScore: 0.01
       }
     )

--- a/backend/src/processStream.ts
+++ b/backend/src/processStream.ts
@@ -212,7 +212,7 @@ export const processCsv =  async (job: Job<any>, jobFile: JobInput): Promise<any
 
 export const processChunk = async (chunk: any[], candidateNumber: number, params: ScoreParams): Promise<any[]> => {
   const bulkRequest = chunk.map((row: any) => { // TODO: type
-    const requestInput = new RequestInput({...row, dateFormat: params.dateFormat});
+    const requestInput = new RequestInput({...row, dateFormat: params.dateFormatA});
     return [JSON.stringify({index: "deces"}), JSON.stringify(buildRequest(requestInput))];
   })
   const msearchRequest = bulkRequest.map((x: any) => x.join('\n\r')).join('\n\r') + '\n';
@@ -239,7 +239,7 @@ export const processChunk = async (chunk: any[], candidateNumber: number, params
 }
 
 const workerChunks = new Worker('chunks', async (chunkJob: Job) => {
-  return await processChunk(chunkJob.data.chunk, chunkJob.data.candidateNumber, {dateFormat: chunkJob.data.dateFormat, pruneScore: chunkJob.data.pruneScore, candidateNumber: chunkJob.data.candidateNumber});
+  return await processChunk(chunkJob.data.chunk, chunkJob.data.candidateNumber, {dateFormatA: chunkJob.data.dateFormatA, pruneScore: chunkJob.data.pruneScore, candidateNumber: chunkJob.data.candidateNumber});
 }, {
   connection: {
     host: 'redis'
@@ -277,7 +277,7 @@ export class ProcessStream extends Transform {
   sourceLineNumber: number;
   jobs: any[];
   totalRows: number;
-  dateFormat: string;
+  dateFormatA: string;
   candidateNumber: number;
   pruneScore: number;
 
@@ -293,7 +293,7 @@ export class ProcessStream extends Transform {
     this.processedRows = 0;
     this.sourceLineNumber = 1;
     this.totalRows = this.job.data.totalRows;
-    this.dateFormat = this.job.data.dateFormat;
+    this.dateFormatA = this.job.data.dateFormatA;
     this.pruneScore = this.job.data.pruneScore;
     this.candidateNumber = this.job.data.candidateNumber;
     this.jobs = [];
@@ -369,7 +369,7 @@ export class ProcessStream extends Transform {
     const job = await chunkQueue
       .add(jobId, {
         chunk: this.batch.map((r: any) => this.toRequest(r)),
-        dateFormat: this.dateFormat,
+        dateFormatA: this.dateFormatA,
         pruneScore: this.pruneScore,
         candidateNumber: this.candidateNumber
       }, {

--- a/backend/src/score.spec.ts
+++ b/backend/src/score.spec.ts
@@ -6,15 +6,14 @@ describe('score.ts - Score function', () => {
 
   it('should return 0.8 as global score', () => {
     const score = new ScoreResult({
-      firstName:  'georges',
-      lastName: 'pompidous',
-      birthDate: "19691101"
+      name: {
+        first: 'georges',
+        last: 'pompidous'
+      },
+      birth: {
+        date: "19691101"
+      }
     }, {
-      score: 0.7,
-      scores: {score: 0},
-      source: '',
-      sourceLine: 212,
-      id: "13",
       name: {
         first: "Georges",
         last: "Pompidou"
@@ -22,30 +21,7 @@ describe('score.ts - Score function', () => {
       sex: "M",
       birth: {
         date: "19691101",
-        location: {
-          city: '',
-          code: '',
-          departmentCode: '',
-          country: '',
-          countryCode: '',
-          latitude: +'',
-          longitude: +'',
-        }
       },
-      death: {
-        date: '',
-        certificateId: '',
-        age: +'',
-        location: {
-          city: '',
-          code: '',
-          departmentCode: '',
-          country: '',
-          countryCode: '',
-          latitude: +'',
-          longitude: +'',
-        }
-      }
     });
     expect(score).to.contain.all.keys(['score', 'birthDate', 'birthLocation', 'name'])
     expect(score.score).to.equal(0.73);
@@ -54,15 +30,16 @@ describe('score.ts - Score function', () => {
 
   it('birth geo score', () => {
     const score = new ScoreResult({
-      firstName:  'georges',
-      lastName: 'pompidous',
-      birthCity: 'Paris'
+      name: {
+        first : 'georges',
+        last: 'pompidous'
+      },
+      birth: {
+        location: {
+          city: 'Paris'
+        }
+      }
     }, {
-      score: 0.7,
-      scores: {score: 0},
-      source: '',
-      sourceLine: 212,
-      id: "13",
       name: {
         first: "Georges",
         last: "Pompidou"
@@ -81,20 +58,6 @@ describe('score.ts - Score function', () => {
           longitude: +'2.439497',
         }
       },
-      death: {
-        date: '',
-        certificateId: '',
-        age: +'',
-        location: {
-          city: '',
-          code: '',
-          departmentCode: '',
-          country: '',
-          countryCode: '',
-          latitude: +'',
-          longitude: +'',
-        }
-      }
     });
     expect(score).to.contain.all.keys(['score', 'birthLocation', 'name'])
     expect(score.birthLocation).to.contain.all.keys(['score', 'city', 'code'])
@@ -104,15 +67,16 @@ describe('score.ts - Score function', () => {
 
   it('birth postal code score', () => {
     const score = new ScoreResult({
-      firstName:  'georges',
-      lastName: 'pompidous',
-      birthPostalCode: '75001'
+      name: {
+        first: 'georges',
+        last: 'pompidous',
+      },
+      birth: {
+        location: {
+          codePostal: '75001'
+        }
+      }
     }, {
-      score: 0.7,
-      scores: {score: 0},
-      source: '',
-      sourceLine: 212,
-      id: "13",
       name: {
         first: "Georges",
         last: "Pompidou"
@@ -132,20 +96,6 @@ describe('score.ts - Score function', () => {
           longitude: +'2.439497',
         }
       },
-      death: {
-        date: '',
-        certificateId: '',
-        age: +'',
-        location: {
-          city: '',
-          code: '',
-          departmentCode: '',
-          country: '',
-          countryCode: '',
-          latitude: +'',
-          longitude: +'',
-        }
-      }
     });
     expect(score).to.contain.all.keys(['score', 'birthLocation', 'name'])
     expect(score.birthLocation).to.contain.all.keys(['score', 'codePostal'])

--- a/backend/src/score.spec.ts
+++ b/backend/src/score.spec.ts
@@ -102,6 +102,33 @@ describe('score.ts - Score function', () => {
 
   });
 
+  it('Score GeoPoint', () => {
+    const score = new ScoreResult({
+      name: {
+        first: 'tran',
+        last: 'chen',
+      },
+      birth: {
+        location: {
+          latitude: 48.847759,
+          longitude: 2.439497
+        }
+      }
+    }, {
+      name: {
+        first: 'tran',
+        last: 'chen',
+      },
+      birth: {
+        location: {
+          latitude: 48.847759,
+          longitude: 2.439497
+        }
+      }
+    });
+    expect(score).to.contain.all.keys(['birthLocation'])
+    expect(score.birthLocation).to.contain.all.keys(['geo'])
+  });
 
   it('explain: Nom d\'usage', () => {
     const score = new ScoreResult({

--- a/backend/src/score.spec.ts
+++ b/backend/src/score.spec.ts
@@ -170,8 +170,8 @@ describe('score.ts - Score function', () => {
         last: "marie"
       },
       sex: "F",
-    });
-    expect(score.explain.name).to.contain.all.keys(['legal'])
+    }, {explain: true});
+    expect(score.explain).to.contain.all.keys(['legalName'])
     expect(score.explain).to.contain.all.keys(['sex'])
 
   });
@@ -189,7 +189,7 @@ describe('score.ts - Score function', () => {
         last: "chen ju wang"
       },
       sex: "F",
-    });
+    }, {explain: true});
     expect(score.explain).to.contain.all.keys(['sex'])
   });
 
@@ -218,7 +218,7 @@ describe('score.ts - Score function', () => {
         }
       },
       sex: "F",
-    });
+    }, {explain: true});
     expect(score.explain).to.contain.all.keys(['sex'])
   })
 

--- a/backend/src/score.spec.ts
+++ b/backend/src/score.spec.ts
@@ -102,4 +102,44 @@ describe('score.ts - Score function', () => {
 
   });
 
+
+  it('explain: Nom d\'usage', () => {
+    const score = new ScoreResult({
+      name: {
+        first: 'jeanne',
+        last: 'michou',
+        legal: 'marie'
+      },
+      sex: 'F'
+    }, {
+      name: {
+        first: "jeanne",
+        last: "marie"
+      },
+      sex: "F",
+    });
+    expect(score.explain.name).to.contain.all.keys(['legal'])
+    expect(score.explain).to.contain.all.keys(['sex'])
+
+  });
+
+  it('explain: Longnames', () => {
+    const score = new ScoreResult({
+      name: {
+        first: 'tran',
+        last: 'chen ju mei wou',
+      },
+      sex: 'F'
+    }, {
+      name: {
+        first: 'tran mi',
+        last: "chen ju wang"
+      },
+      sex: "F",
+    });
+    expect(score.explain).to.contain.all.keys(['sex'])
+
+  });
+
+
 });

--- a/backend/src/score.spec.ts
+++ b/backend/src/score.spec.ts
@@ -27,6 +27,32 @@ describe('score.ts - Score function', () => {
     expect(score.score).to.equal(0.73);
   });
 
+  it('special: should return 0.8 as global score different date format', () => {
+    const score = new ScoreResult({
+      name: {
+        first: 'georges',
+        last: 'pompidous'
+      },
+      birth: {
+        date: "01/11/1969"
+      }
+    }, {
+      name: {
+        first: "Georges",
+        last: "Pompidou"
+      },
+      sex: "M",
+      birth: {
+        date: "01/11/1969",
+      },
+    },{
+      dateFormatA: "dd/MM/yyyy",
+      dateFormatB: "dd/MM/yyyy"
+    });
+    expect(score).to.contain.all.keys(['score', 'birthDate', 'birthLocation', 'name'])
+    expect(score.score).to.equal(0.73);
+  });
+
 
   it('birth geo score', () => {
     const score = new ScoreResult({
@@ -165,8 +191,36 @@ describe('score.ts - Score function', () => {
       sex: "F",
     });
     expect(score.explain).to.contain.all.keys(['sex'])
-
   });
+
+  it('explain: location', () => {
+    const score = new ScoreResult({
+      name: {
+        first: 'tran',
+        last: 'chen ju mei wou',
+      },
+      birth: {
+        location: {
+          city: "Paris",
+          countryCode: 'FRA',
+        }
+      },
+      sex: 'F'
+    }, {
+      name: {
+        first: 'tran mi',
+        last: "chen ju wang"
+      },
+      birth: {
+        location: {
+          city: "Parisi",
+          countryCode: 'FRA',
+        }
+      },
+      sex: "F",
+    });
+    expect(score.explain).to.contain.all.keys(['sex'])
+  })
 
 
 });

--- a/backend/src/score.ts
+++ b/backend/src/score.ts
@@ -667,8 +667,8 @@ export class ScoreResult {
       if (persA.birth && persA.birth.date) {
         this.birthDate = scoreDate(persA.birth.date, persB.birth.date, params.dateFormat,
           persB.birth && persB.birth.location && persB.birth.location.countryCode && (persB.birth.location.countryCode !== 'FRA')
-          );
-        explain = {birth: {date: {location: {france: true}}}}
+        );
+        updateObjProp(explain, 'birth.date.location.france', true)
       }
       if (persA.name && (persA.name.first || persA.name.last)) {
         if ((pruneScore < scoreReduce(this, true)) || !this.birthDate) {
@@ -733,11 +733,12 @@ export class ScoreResult {
 
 export const personFromRequest = (item: RequestBody): Person => {
   return {
-    ...(item.firstName || item.lastName) && {name: {
+    ...(item.firstName || item.lastName || item.legalName) && {name: {
       ...item.firstName && { first: item.firstName },
       ...item.lastName && { last: item.lastName },
       ...item.legalName && { legal: item.legalName }
     }},
+    ...item.sex && { sex: item.sex as 'M'|'F' },
     ...(item.birthDate || item.birthCity || item.birthLocationCode || item.birthDepartment || item.birthCountry ) && { birth: {
       ...item.birthDate && { date: item.birthDate as string },
       ...(item.birthCity || item.birthLocationCode || item.birthDepartment || item.birthCountry) && { location: {

--- a/backend/src/score.ts
+++ b/backend/src/score.ts
@@ -203,18 +203,18 @@ let scoreName = (nameA: Name, nameB: Name, sex: string, explain?: any): any => {
     let thisLastNamePenalty;
     if ((Array.isArray(lastAtokens) && (lastAtokens.length > 2)) || (Array.isArray(lastBtokens) && (lastBtokens.length > 2))) {
       thisLastNamePenalty = 1
-      updateObjProp(explain, 'name.longname', true)
-      updateObjProp(explain, 'name.last.namePenalty', lastNamePenalty)
+      updateObjProp(explain, 'lastName.longname', true)
+      updateObjProp(explain, 'lastName.penalty', lastNamePenalty)
     } else {
       thisLastNamePenalty = lastNamePenalty
-      updateObjProp(explain, 'name.longname', false)
-      updateObjProp(explain, 'name.last.namePenalty', lastNamePenalty)
+      updateObjProp(explain, 'lastName.longname', false)
+      updateObjProp(explain, 'lastName.penalty', lastNamePenalty)
     }
     let firstFirstA; let firstFirstB; let scoreFirstALastB; let fuzzScore;
     const scoreFirst = round(scoreToken(firstA, firstB));
     const scoreLast = round(scoreToken(lastA, lastB));
-    updateObjProp(explain, 'name.first.levenshteinScore', scoreFirst)
-    updateObjProp(explain, 'name.last.levenshteinScore', scoreLast)
+    updateObjProp(explain, 'firstName.levenshteinScore', scoreFirst)
+    updateObjProp(explain, 'lastName.levenshteinScore', scoreLast)
     score = round(Math.max(
                 scoreFirst * (scoreLast ** thisLastNamePenalty),
                 Math.max(
@@ -252,7 +252,8 @@ let scoreName = (nameA: Name, nameB: Name, sex: string, explain?: any): any => {
                     nameInversionPenalty * (scoreFirstALastB ** thisLastNamePenalty) * scoreToken(lastA, firstFirstB) ** thisLastNamePenalty
                 )
             );
-            updateObjProp(explain, 'name.nameSwap', true)
+            updateObjProp(explain, 'firstName.nameSwap', true)
+            updateObjProp(explain, 'lastName.nameSwap', true)
         }
     }
     score = { score, first: scoreFirst, last: scoreLast };
@@ -278,7 +279,7 @@ let scoreName = (nameA: Name, nameB: Name, sex: string, explain?: any): any => {
         if (particleScore > score.score) {
             score.score = particleScore;
             score.particleScore = particleScore;
-            updateObjProp(explain, 'name.particles', true)
+            updateObjProp(explain, 'firstName.particles', true)
         }
     }
     return score;
@@ -469,7 +470,7 @@ let scoreLocation = (locA: Location, locB: Location, event?: string, explain?: a
       score.geo = scoreGeo(locA.latitude, locA.longitude, locB.latitude, locB.longitude)
     }
     if (BisFrench) {
-        updateObjProp(explain, `${event}Location.country`, 'France')
+        updateObjProp(explain, `${event}Country`, 'France')
         if (normalize(locA.country as string|string[])) {
             score.country = scoreCountry(locA.country, tokenize(locB.country as string));
             if ((score.code >= round(blindLocationScore ** 0.5)) && (score.country < perfectScoreThreshold)) {
@@ -478,7 +479,7 @@ let scoreLocation = (locA: Location, locB: Location, event?: string, explain?: a
             }
         }
         if (normalize(locA.city as string|string[]) && locB.city) {
-            updateObjProp(explain, `${event}Location.surface`, communesDict[cityNorm(locA.city as string) as string].surface)
+            updateObjProp(explain, `${event}City.surface`, communesDict[cityNorm(locA.city as string) as string].surface)
             score.city = scoreCity(locA.city, locB.city as string|string[]);
             if ((score.code === 1) && (score.city < perfectScoreThreshold)) {
                 // insee code has priority over label
@@ -673,7 +674,7 @@ export class ScoreResult {
         this.birthDate = scoreDate(persA.birth.date, persB.birth.date, params.dateFormatA, params.dateFormatB,
           persB.birth && persB.birth.location && persB.birth.location.countryCode && (persB.birth.location.countryCode !== 'FRA')
         );
-        updateObjProp(explain, 'birth.date.location.france', true)
+        updateObjProp(explain, 'birthCountry', 'France')
       }
       if (persA.name && (persA.name.first || persA.name.last)) {
         if ((pruneScore < scoreReduce(this, true)) || !this.birthDate) {
@@ -681,7 +682,7 @@ export class ScoreResult {
               updateObjProp(explain, 'sex', 'F')
               if (persA.name.legal) {
                   this.name = scoreName({first: persA.name.first, last: [persA.name.last as string, persA.name.legal as string]}, persB.name, 'F', explain);
-                  updateObjProp(explain, 'name.legal', true)
+                  updateObjProp(explain, 'legalName', true)
               } else {
                   this.name = scoreName(persA.name, persB.name, 'F', explain);
               }

--- a/backend/src/score.ts
+++ b/backend/src/score.ts
@@ -439,9 +439,9 @@ const scoreCountry = (countryA: string|string[]|RequestField, countryB: string|s
         if (typeof(countryB) === 'string') {
             return fuzzyRatio(countryNormA, countryNorm(countryB) as string, fuzzballTokenSetRatio);
         } else {
-            return Math.max(...countryB.map(country => fuzzyRatio(countryNormA, countryNorm(country) as string, fuzzballTokenSetRatio)),
+            return Array.isArray(countryB) ? Math.max(...countryB.map(country => fuzzyRatio(countryNormA, countryNorm(country) as string, fuzzballTokenSetRatio)),
                 fuzzballTokenSetRatio(countryNormA, countryB.join(' '))
-                );
+                ) : fuzzballTokenSetRatio(countryNormA, countryB);
         }
     } else {
         const countryNormB = countryNorm(countryB);
@@ -662,7 +662,7 @@ export class ScoreResult {
     constructor(persA: Person, persB: Person, params: ScoreParams = {}) {
       // if params.explain == True
       // this.explain = {}
-      let explain = {}
+      const explain = {}
       const pruneScore = params.pruneScore !== undefined ? params.pruneScore : defaultPruneScore
       if (persA.birth && persA.birth.date) {
         this.birthDate = scoreDate(persA.birth.date, persB.birth.date, params.dateFormat,

--- a/backend/src/score.ts
+++ b/backend/src/score.ts
@@ -659,66 +659,66 @@ export class ScoreResult {
     birthLocation?: number;
     deathLocation?: number;
 
-    constructor(request: Person, result: Person, params: ScoreParams = {}) {
+    constructor(persA: Person, persB: Person, params: ScoreParams = {}) {
       // if params.explain == True
       // this.explain = {}
       let explain = {}
       const pruneScore = params.pruneScore !== undefined ? params.pruneScore : defaultPruneScore
-      if (request.birth && request.birth.date) {
-        this.birthDate = scoreDate(request.birth.date, result.birth.date, params.dateFormat,
-          result.birth && result.birth.location && result.birth.location.countryCode && (result.birth.location.countryCode !== 'FRA')
+      if (persA.birth && persA.birth.date) {
+        this.birthDate = scoreDate(persA.birth.date, persB.birth.date, params.dateFormat,
+          persB.birth && persB.birth.location && persB.birth.location.countryCode && (persB.birth.location.countryCode !== 'FRA')
           );
         explain = {birth: {date: {location: {france: true}}}}
       }
-      if (request.name && (request.name.first || request.name.last)) {
+      if (persA.name && (persA.name.first || persA.name.last)) {
         if ((pruneScore < scoreReduce(this, true)) || !this.birthDate) {
-          if (result.sex && result.sex === 'F') {
+          if (persB.sex && persB.sex === 'F') {
               updateObjProp(explain, 'sex', 'F')
-              if (request.name.legal) {
-                  this.name = scoreName({first: request.name.first, last: [request.name.last as string, request.name.legal as string]}, result.name, 'F', explain);
+              if (persA.name.legal) {
+                  this.name = scoreName({first: persA.name.first, last: [persA.name.last as string, persA.name.legal as string]}, persB.name, 'F', explain);
                   updateObjProp(explain, 'name.legal', true)
               } else {
-                  this.name = scoreName(request.name, result.name, 'F', explain);
+                  this.name = scoreName(persA.name, persB.name, 'F', explain);
               }
           } else {
-            this.name = scoreName(request.name, result.name, 'M');
+            this.name = scoreName(persA.name, persB.name, 'M');
             updateObjProp(explain, 'sex', 'M')
           }
         } else {
           this.score = 0
         }
       }
-      if (request.sex) {
+      if (persA.sex) {
         if (pruneScore < scoreReduce(this, true)) {
-          this.sex = scoreSex(request.sex, result.sex);
+          this.sex = scoreSex(persA.sex, persB.sex);
         } else {
           this.score = 0
         }
-      } else if (request.name && request.name.first && firstNameSexMismatch(request.name.first as string, result.name.first as string)) {
+      } else if (persA.name && persA.name.first && firstNameSexMismatch(persA.name.first as string, persB.name.first as string)) {
           this.sex = firstNameSexPenalty;
       }
       // birthLocation
       if (pruneScore < scoreReduce(this, true)) {
           this.birthLocation = scoreLocation(
-            request.birth && request.birth.location ? request.birth.location : {},
-            result.birth && result.birth.location ? result.birth.location: {});
+            persA.birth && persA.birth.location ? persA.birth.location : {},
+            persB.birth && persB.birth.location ? persB.birth.location: {});
       } else {
           this.score = 0
       }
-      if (request.death && request.death.date) {
+      if (persA.death && persA.death.date) {
           if (pruneScore < scoreReduce(this, true)) {
-              this.deathDate = scoreDate(request.death.date, result.death.date, params.dateFormat,
-                  result.death && result.death.location && result.death.location.countryCode && (result.death.location.countryCode !== 'FRA')
+              this.deathDate = scoreDate(persA.death.date, persB.death.date, params.dateFormat,
+                  persB.death && persB.death.location && persB.death.location.countryCode && (persB.death.location.countryCode !== 'FRA')
               );
           } else {
               this.score = 0
           }
       }
-      if (request.death && request.death.location && (request.death.location.city || request.death.location.code || request.death.location.country || request.death.location.departmentCode || request.death.location.latitude)) {
+      if (persA.death && persA.death.location && (persA.death.location.city || persA.death.location.code || persA.death.location.country || persA.death.location.departmentCode || persA.death.location.latitude)) {
           if (pruneScore < scoreReduce(this, true)) {
               this.deathLocation = scoreLocation(
-                request.death && request.death.location ? request.death.location : {},
-                result.death && result.death.location ? result.death.location : {});
+                persA.death && persA.death.location ? persA.death.location : {},
+                persB.death && persB.death.location ? persB.death.location : {});
           } else {
               this.score = 0
           }

--- a/backend/src/score.ts
+++ b/backend/src/score.ts
@@ -741,21 +741,23 @@ export const personFromRequest = (item: RequestBody): Person => {
     ...item.sex && { sex: item.sex as 'M'|'F' },
     ...(item.birthDate || item.birthCity || item.birthLocationCode || item.birthDepartment || item.birthCountry ) && { birth: {
       ...item.birthDate && { date: item.birthDate as string },
-      ...(item.birthCity || item.birthLocationCode || item.birthDepartment || item.birthCountry) && { location: {
+      ...(item.birthCity || item.birthLocationCode || item.birthDepartment || item.birthCountry || item.birthGeoPoint) && { location: {
         ...item.birthCity && { city: item.birthCity },
         ...item.birthLocationCode && { code: item.birthLocationCode },
         ...item.birthDepartment && { departmentCode: item.birthDepartment },
-        ...item.birthCountry && { country: item.birthCountry }
+        ...item.birthCountry && { country: item.birthCountry },
+        ...item.birthGeoPoint && { latitude: item.birthGeoPoint.latitude, longitude: item.birthGeoPoint.longitude }
     }}}},
     ...(item.deathDate || item.deathCity || item.deathLocationCode || item.deathDepartment || item.deathCountry ) && { death: {
       // deathDate has priority over lastSeenAliveDate
       ...item.lastSeenAliveDate && { date: `>${item.lastSeenAliveDate}`},
       ...item.deathDate && { date: item.deathDate as string },
-      ...(item.deathCity || item.deathLocationCode || item.deathDepartment || item.deathCountry) && { location: {
+      ...(item.deathCity || item.deathLocationCode || item.deathDepartment || item.deathCountry || item.deathGeoPoint) && { location: {
         ...item.deathCity && { city: item.deathCity },
         ...item.deathLocationCode && { code: item.deathLocationCode },
         ...item.deathDepartment && { departmentCode: item.deathDepartment },
-        ...item.deathCountry && { country: item.deathCountry }
+        ...item.deathCountry && { country: item.deathCountry },
+        ...item.deathGeoPoint && { latitude: item.deathGeoPoint.latitude, longitude: item.deathGeoPoint.longitude }
     }}}}
   }
 }


### PR DESCRIPTION
**Update** La fonction score résultats permet d'obtenir optionnellement de détails sur le calcul du score 

Modification de la fonction score pour réutiliser la fonction pour comparer des identités, indépendamment de la base de données de personnes décédées. 

On peut maintenant utiliser des requêtes comme la suivante pour comparer des identités:

```
curl -X 'POST' \
  'http://localhost:8084/deces/api/v1/compare' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "personA": {
    "firstName": "Georges",
    "lastName": "Pompidou",
    "sex": "M",
    "deathCity": "Paris"
  },
  "personB": {
    "firstName": "Georges",
    "lastName": "Pompidou",
    "sex": "M",
    "deathCity": "Paris"
  }
}'
```

Pour moi c'est la première étape pour le chantier d'explicabilité.