### PR TITLE
➖ Get rid of unused parameter from JobOptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ wikidata-links: ${WIKIDATA_LINKS}
 ${COMMUNES_JSON}:
 	@echo "downloading communes geo data"
 	@sudo apt-get install gdal-bin
-	@curl -s -L -l 'https://www.data.gouv.fr/fr/datasets/r/0e117c06-248f-45e5-8945-0e79d9136165' -o communes-20220101.zip
+	@curl -s -k -L -l 'https://www.data.gouv.fr/fr/datasets/r/0e117c06-248f-45e5-8945-0e79d9136165' -o communes-20220101.zip
 	@unzip -o  communes-20220101.zip  -d communes-20220101
 	@ogr2ogr -f GeoJSON -s_srs EPSG:26917 -t_srs EPSG:4326 communes-20220101.json communes-20220101/communes-20220101.shp -simplify 0.001
 	@rm -rf communes-20220101

--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,8 @@ wikidata-links: ${WIKIDATA_LINKS}
 ${COMMUNES_JSON}:
 	@echo "downloading communes geo data"
 	@sudo apt-get install gdal-bin
-	@curl -s -k -L -l 'https://www.data.gouv.fr/fr/datasets/r/0e117c06-248f-45e5-8945-0e79d9136165' -o communes-20220101.zip
+	@curl -L -l 'https://www.data.gouv.fr/fr/datasets/r/0e117c06-248f-45e5-8945-0e79d9136165' -o communes-20220101.zip
+	@echo "finish downloading"
 	@unzip -o  communes-20220101.zip  -d communes-20220101
 	@ogr2ogr -f GeoJSON -s_srs EPSG:26917 -t_srs EPSG:4326 communes-20220101.json communes-20220101/communes-20220101.shp -simplify 0.001
 	@rm -rf communes-20220101

--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ wikidata-links: ${WIKIDATA_LINKS}
 ${COMMUNES_JSON}:
 	@echo "downloading communes geo data"
 	@sudo apt-get install gdal-bin
-	@curl -L -l 'https://www.data.gouv.fr/fr/datasets/r/0e117c06-248f-45e5-8945-0e79d9136165' -o communes-20220101.zip
+	@curl --retry 5 -L -l 'https://www.data.gouv.fr/fr/datasets/r/0e117c06-248f-45e5-8945-0e79d9136165' -o communes-20220101.zip
 	@echo "finish downloading"
 	@unzip -o  communes-20220101.zip  -d communes-20220101
 	@ogr2ogr -f GeoJSON -s_srs EPSG:26917 -t_srs EPSG:4326 communes-20220101.json communes-20220101/communes-20220101.shp -simplify 0.001

--- a/backend/src/processStream.ts
+++ b/backend/src/processStream.ts
@@ -373,7 +373,6 @@ export class ProcessStream extends Transform {
         pruneScore: this.pruneScore,
         candidateNumber: this.candidateNumber
       }, {
-        timeout: 30000,
         attempts: 2,
         jobId
       })


### PR DESCRIPTION
Bullmq doesn't use `timeout` parameter anymore
https://github.com/taskforcesh/bullmq/commit/cdd2a20c2c4ca47042ecd1da525ecb72941e4910