### PR TITLE
Fix/protect queue api

### DIFF
--- a/backend/src/controllers/job.controller.ts
+++ b/backend/src/controllers/job.controller.ts
@@ -15,6 +15,7 @@ export class JobsController extends Controller {
    * @summary Vérifier le nombre de jobs
    * @param name Name of queue
    */
+  @Security("jwt", ["admin"])
   @Tags('Jobs')
   @Get('')
   public async jobName(

--- a/backend/src/controllers/job.controller.ts
+++ b/backend/src/controllers/job.controller.ts
@@ -50,7 +50,7 @@ export class JobsController extends Controller {
   @Get('{queueName}')
   public async getJobs(
 
-    @Path() queueName: 'jobs'|'chunks',
+    @Path() queueName: 'jobs',
     @Query() jobId?: string,
     @Query() jobsType?: string,
   ): Promise<any> {
@@ -60,9 +60,7 @@ export class JobsController extends Controller {
       }
     });
     if (['wait', 'active', 'delayed', 'completed', 'failed'].includes(jobsType)) {
-      const queueScheduler = new Queue(queueName, { connection: { host: 'redis'}});
       const jobs = await jobQueue.getJobs(['wait', 'active', 'delayed', 'completed', 'failed']);
-      await queueScheduler.close();
       return { jobs };
     } else if (jobId) {
       const jobs = await jobQueue.getJob(jobsType)

--- a/backend/src/controllers/job.controller.ts
+++ b/backend/src/controllers/job.controller.ts
@@ -1,8 +1,6 @@
 import { Queue, JobType } from 'bullmq';
 import { Controller, Get, Route, Tags, Path, Query, Security } from 'tsoa';
 
-const jobTypesList: JobType[] = ['completed', 'failed', 'active', 'delayed', 'waiting', 'waiting-children', 'paused', 'repeat', 'wait']
-
 /**
  * @swagger
  * tags:
@@ -28,12 +26,7 @@ export class JobsController extends Controller {
           host: 'redis'
         }
       });
-      const jobsSum:any = {}
-      for (const jobType of jobTypesList) {
-        const jobsTmp = await jobQueue.getJobs(jobType);
-        jobsSum[jobType] = jobsTmp.reduce((sum) => sum +1, 0)
-      }
-      return jobsSum;
+      return await jobQueue.getJobCounts();
     } else {
       return {msg: 'available queues: "chunks" and "jobs". Use them as a query parameter. For example name=jobs'};
     }

--- a/backend/src/processStream.ts
+++ b/backend/src/processStream.ts
@@ -58,6 +58,9 @@ const chunkEvents = new QueueEvents('chunks', {
 const chunkQueue = new Queue('chunks',  {
   connection: {
     host: 'redis'
+  },
+  defaultJobOptions: {
+    removeOnFail: true
   }
 });
 

--- a/backend/src/processStream.ts
+++ b/backend/src/processStream.ts
@@ -379,6 +379,7 @@ export class ProcessStream extends Transform {
     await job.waitUntilFinished(chunkEvents)
     const jobResult = await Job.fromId(chunkQueue, job.id)
     this.jobs.push({id: jobId, result: jobResult.returnvalue})
+    await job.remove();
     this.batch = [];
   }
 

--- a/backend/src/server.spec.ts
+++ b/backend/src/server.spec.ts
@@ -441,6 +441,16 @@ describe('server.ts - Express application', () => {
         .on('end', (rowCount: number) => {
           expect(rowCount).to.eql(nrows - 1);
         });
+
+      // verify that chunks info has been deleted
+      res = await chai.request(app)
+        .get(apiPath('queue?name=chunks'))
+        .set('Authorization', `Bearer ${token.body.access_token as string}`)
+      Object.values(res.body).forEach(jobType => {
+        expect(jobType).to.eql(0);
+      })
+
+      // verify that crypted files are deleted ater timeout
       await new Promise(resolve => setTimeout(resolve, Number(process.env.BACKEND_TMPFILE_PERSISTENCE || "3000")));
       setTimeout(() => {
         fs.readdirSync("./").forEach(file => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -43,7 +43,7 @@ const formatAsJson = (tokens: any, req: any, res: any) => {
       'forwarded-address': tokens['fwd-addr'](req, res),
       'remote-user': tokens['remote-user'](req, res),
       'server-date': tokens.date(req, res, 'iso'),
-      'user':req.user && req.user.user && crypto.createHash('sha256').update(req.user.user).digest('hex').substring(0, 16),
+      'user':req.user && req.user.user,
       'response-time': +tokens['response-time'](req, res, 'iso'),
       method: tokens.method(req, res),
       url: tokens.url(req, res),


### PR DESCRIPTION
- adds Security with admin rights to root api 'queue'
- removes obsfuscation in mail logs, to enable e2e postfix-to-backend tracabiltiy & statistics
  for this policy: for now, log are not long term archived so this is RGPD compliant (security standard usage <12 months)
  postfix cant be obfuscated for security reasons for now (in a short term view) or would need tagging of mail relying on gmail (where we can put rules of mid-term cleasing)