### PR TITLE
🎨 Add deces-update index

### DIFF
--- a/backend/src/buildRequest.ts
+++ b/backend/src/buildRequest.ts
@@ -389,7 +389,7 @@ const buildFrom = (current: number, resultsPerPage: number) => {
   return (current - 1) * resultsPerPage;
 }
 
-const referenceSort: any = {
+export const referenceSort: any = {
   score: "_score",
   firstName: "PRENOM.raw",
   lastName: "NOM.raw",

--- a/backend/src/controllers/search.controller.ts
+++ b/backend/src/controllers/search.controller.ts
@@ -263,7 +263,12 @@ export class SearchController extends Controller {
     @Request() request: express.Request
   ): Promise<any> {
     const date = new Date(Date.now()).toISOString()
-    await this.storeProof(request);
+    try {
+      await this.storeProof(request);
+    } catch (err) {
+      this.setStatus(400);
+      return { msg: err.message };
+    }
     // get user & rights from Security
     const author = (request as any).user && (request as any).user.user
     const isAdmin = (request as any).user && (request as any).user.scopes && (request as any).user.scopes.includes('admin');

--- a/backend/src/controllers/search.controller.ts
+++ b/backend/src/controllers/search.controller.ts
@@ -5,14 +5,14 @@ import express from 'express';
 import { writeFile, access, mkdir, createReadStream } from 'fs';
 import { promisify } from 'util';
 import { resultsHeader, jsonPath, prettyString } from '../processStream';
-import { runRequest, runBulkRequest } from '../runRequest';
+import { runRequest } from '../runRequest';
 import { buildRequest } from '../buildRequest';
 import { RequestInput, RequestBody } from '../models/requestInput';
 import { StrAndNumber, Modification, UpdateRequest, UpdateUserRequest, Review, ReviewsStringified, statusAuthMap, PersonCompare } from '../models/entities';
-import { buildResult, buildResultSingle, Result, ErrorResponse } from '../models/result';
+import { buildResult, Result, ErrorResponse } from '../models/result';
 import { format } from '@fast-csv/format';
 import { ScoreResult, personFromRequest } from '../score';
-import { updatedFields } from '../updatedIds';
+import { getAllUpdates, getAuthorUpdates, updatedFields, resultsFromUpdates, cleanRawUpdates, addModification } from '../updatedIds';
 import { sendUpdateConfirmation } from '../mail';
 // import getDataGouvCatalog from '../getDataGouvCatalog';
 
@@ -262,8 +262,9 @@ export class SearchController extends Controller {
     @Body() updateRequest: UpdateRequest,
     @Request() request: express.Request
   ): Promise<any> {
+    const date = new Date(Date.now()).toISOString()
+    await this.storeProof(request);
     // get user & rights from Security
-    await this.handleFile(request);
     const author = (request as any).user && (request as any).user.user
     const isAdmin = (request as any).user && (request as any).user.scopes && (request as any).user.scopes.includes('admin');
     const requestInput = new RequestInput({id});
@@ -271,7 +272,6 @@ export class SearchController extends Controller {
     const result = await runRequest(requestBuild, requestInput.scroll);
     const builtResult = buildResult(result.data, requestInput)
     if (builtResult.response.persons.length > 0) {
-      const date = new Date(Date.now()).toISOString()
       const bytes = forge.random.getBytesSync(24);
       const randomId = forge.util.bytesToHex(bytes);
       if (!isAdmin) {
@@ -293,7 +293,7 @@ export class SearchController extends Controller {
           return { msg: 'Proof must be provided' }
         }
         delete updateRequest.proof;
-        const correctionData: Modification = {
+        const modification: Modification = {
           id: randomId,
           date,
           proof,
@@ -302,17 +302,15 @@ export class SearchController extends Controller {
           fields: updateRequest
         };
         if (message) {
-          correctionData.message = message;
+          modification.message = message;
         }
-        try {
-          await accessAsync(`${process.env.PROOFS}/${id}`);
-        } catch(err) {
-          await mkdirAsync(`${process.env.PROOFS}/${id}`, { recursive: true });
+        const success = await addModification(id, modification, date);
+        if (success) {
+          return { msg: "Update stored" };
+        } else {
+          this.setStatus(500);
+          return { msg: "Update failed" };
         }
-        await writeFileAsync(`${process.env.PROOFS}/${id}/${date}_${id}.json`, JSON.stringify(correctionData));
-        if (!updatedFields[id]) { updatedFields[id] = [] }
-        updatedFields[id].push(correctionData);
-        return { msg: "Update stored" };
       } else {
         if (!updatedFields[id]) {
           this.setStatus(406);
@@ -383,47 +381,13 @@ export class SearchController extends Controller {
   public async updateList(@Request() request: express.Request): Promise<any>  {
     const author = (request as any).user && (request as any).user.user
     const isAdmin = (request as any).user && (request as any).user.scopes && (request as any).user.scopes.includes('admin');
-    let updates:any = {};
-    if (isAdmin) {
-      updates = {...updatedFields};
-    } else {
-      Object.keys(updatedFields).forEach((id:any) => {
-        let filter = false;
-        const modifications = updatedFields[id].map((m:any) => {
-          const modif:any = {...m}
-          if (modif.author !== author) {
-            modif.author = modif.author.substring(0,2)
-              + '...' + modif.author.replace(/@.*/,'').substring(modif.author.replace(/@.*/,'').length-2)
-              + '@' + modif.author.replace(/.*@/,'');
-            modif.message = undefined;
-            modif.review = undefined;
-          } else {
-            filter=true
-          }
-          return modif;
-        });
-        if (filter) {
-          updates[id] = modifications;
-        }
-      })
-    }
+    const updates:any = isAdmin ? getAllUpdates() : getAuthorUpdates(author);
     if (Object.keys(updates).length === 0) return []
-    const bulkRequest = Object.keys(updates).map((id: any) =>
-      [JSON.stringify({index: "deces"}), JSON.stringify(buildRequest(new RequestInput({id})))]
-    );
-    const msearchRequest = bulkRequest.map((x: any) => x.join('\n\r')).join('\n\r') + '\n';
-    const result =  await runBulkRequest(msearchRequest);
-    return  result.data.responses.map((r:any) => buildResultSingle(r.hits.hits[0]))
-      .filter((r:any) => Object.keys(r).length > 0)
-      .map((r:any) => {
-        delete r.score;
-        delete r.scores;
-        r.modifications = updates[r.id];
-        return r;
-      });
+    const rawUpdates = await resultsFromUpdates(updates);
+    return await cleanRawUpdates(rawUpdates, updates);
   }
 
-  private async handleFile(request: express.Request): Promise<any> {
+  private async storeProof(request: express.Request): Promise<any> {
     const storage = multer.diskStorage({
       destination: void(async (req: any, file: any, cb: any) => {
         if (file.mimetype !== 'application/pdf') {

--- a/backend/src/controllers/search.spec.ts
+++ b/backend/src/controllers/search.spec.ts
@@ -1,7 +1,12 @@
 import { SearchController } from './search.controller';
 import { PersonCompare } from '../models/entities';
 import express from 'express';
-import { describe, expect, it } from 'vitest'
+import { initUpdateIndex } from '../updatedIds';
+import { describe, expect, it, beforeAll } from 'vitest'
+
+beforeAll(async () => {
+  await initUpdateIndex();
+})
 
 describe('search.controller.ts - GET request', () => {
   const controller = new SearchController()
@@ -90,7 +95,7 @@ describe('search.controller.ts - POST id', () => {
   it('update id', async () => {
     const body = {
       'author_id': 'Ked3oh@oPho3m.com',
-      lastName: 'Aiph7u',
+      lastName: 'Aeboox9e',
       proof: 'https://somwhere.in.the.internet',
     }
     const req = {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,10 @@
 import { app } from './server';
+import { initUpdateIndex, updateFieldsToIndex, getAllUpdates } from './updatedIds';
+
+
+initUpdateIndex();
+const updates = getAllUpdates();
+updateFieldsToIndex(updates);
 
 const port = 8080;
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,14 +1,15 @@
 import { app } from './server';
 import { initUpdateIndex, updateFieldsToIndex, getAllUpdates } from './updatedIds';
 
-
-initUpdateIndex();
-const updates = getAllUpdates();
-updateFieldsToIndex(updates);
-
 const port = 8080;
 
-app.listen( port, () => {
-  // eslint-disable-next-line no-console
-  console.log( `server started at http://localhost:${ port }` );
-} );
+(async () => {
+  await initUpdateIndex();
+  const updates = getAllUpdates();
+  await updateFieldsToIndex(updates);
+
+  app.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`server started at http://localhost:${port}`);
+  });
+})();

--- a/backend/src/models/entities.ts
+++ b/backend/src/models/entities.ts
@@ -134,6 +134,7 @@ export interface Modification {
 }
 
 export interface Person {
+    index?: string;
     score?: number;
     source?: string;
     sourceLine?: number;

--- a/backend/src/models/result.ts
+++ b/backend/src/models/result.ts
@@ -220,8 +220,14 @@ export const buildResult = (result: ResultRawES, requestInput: RequestInput): Re
   filteredResults
     .forEach((value, index, self) => {
       const firstIndex = self.findIndex((item) => item.id === value.id);
-      if (index !== firstIndex && value.index !== self[firstIndex].index) {
-        self.splice(firstIndex, 1);
+      if (index !== firstIndex) {
+        // Prioritize 'deces-updates' index over 'deces'
+        const shouldRemoveFirst = self[firstIndex].index === 'deces' && value.index === 'deces-updates';
+        if (shouldRemoveFirst) {
+          self.splice(firstIndex, 1);
+        } else if (value.index === 'deces') {
+          self.splice(index, 1);
+        }
       }
     })
 
@@ -310,8 +316,10 @@ export const buildResultSingle = (item: ResultRawHit): Person|undefined => {
       const update: any = {...u};
       // WIP quick n dirty anonymization
       const { author } = u;
-      update.author = author ? author.substring(0,2)
-        + '...' + author.replace(/@.*/,'').substring(author.replace(/@.*/,'').length-2)
+      update.author = author ? 
+        (author.length > 8 ? 
+          author.substring(0,2) + '...' + author.replace(/@.*/,'').substring(author.replace(/@.*/,'').length-2)
+          : '...') 
         + '@' + author.replace(/.*@/,'') : "";
       return update;
     });

--- a/backend/src/processStream.ts
+++ b/backend/src/processStream.ts
@@ -19,6 +19,15 @@ import iconv from 'iconv-lite';
 
 import timer from './timer';
 
+const log = (json:any) => {
+    loggerStream.write(JSON.stringify({
+      "backend": {
+        "server-date": new Date(Date.now()).toISOString(),
+        ...json
+      }
+    }));
+}
+
 const timerRunBulkRequest = timer(runBulkRequest, 'runBulkRequest', 1);
 
 export const validFields: string[] = ['q', 'firstName', 'lastName', 'legalName', 'sex', 'birthDate', 'birthCity', 'birthLocationCode', 'birthPostalCode', 'birthDepartment', 'birthCountry',
@@ -26,15 +35,6 @@ export const validFields: string[] = ['q', 'firstName', 'lastName', 'legalName',
 'size', 'fuzzy', 'block'];
 const validFieldsForColumnsCount = ['firstName', 'lastName', 'legalName', 'sex', 'birthDate', 'birthCity', 'birthLocationCode', 'birthPostalCode', 'birthDepartment', 'birthCountry',
 'birthGeoPoint', 'deathDate', 'deathCity', 'deathLocationCode', 'deathPostalCode', 'deathDepartment', 'deathCountry', 'deathGeoPoint', 'deathAge', 'lastSeenAliveDate']
-
-const log = (json:any) => {
-  loggerStream.write(JSON.stringify({
-    "backend": {
-      "server-date": new Date(Date.now()).toISOString(),
-      ...json
-    }
-  }));
-}
 
 const formatJob = (job:any) => {
   const duration: number = job && job.processedOn && job.finishedOn && (job.finishedOn - job.processedOn) / 1000;
@@ -134,7 +134,6 @@ const JsonParseStream = () => {
     objectMode: true,
     transform(row: any, encoding: string, callback: (e?: any) => void) {
         try {
-          // loggerStream.write(`jsonParse ${row}\n`);
           this.push(JSON.parse(row));
           callback();
         } catch(e) {

--- a/backend/src/runRequest.ts
+++ b/backend/src/runRequest.ts
@@ -6,9 +6,9 @@ export const runRequest = async (body: BodyResponse|ScrolledResponse, scroll: st
   if (body.scroll_id) {
     endpoint = '_search/scroll'
   } else if (scroll) {
-    endpoint = `deces/_search?scroll=${scroll}`
+    endpoint = `deces,deces-updates/_search?scroll=${scroll}`
   } else {
-    endpoint = 'deces/_search'
+    endpoint = 'deces,deces-updates/_search'
   }
   const response = await axios(`http://elasticsearch:9200/${endpoint}`, {
     method: 'post',

--- a/backend/src/tsoa.ts
+++ b/backend/src/tsoa.ts
@@ -16,7 +16,8 @@ import { generateRoutes, generateSpec, ExtendedRoutesConfig, ExtendedSpecConfig 
         flow: "password",
         tokenUrl: "/deces/api/v1/auth",
         scopes: {
-          admin: "administration access"
+          admin: "administration access",
+          user: "user access"
         }
       },
     }

--- a/backend/src/updatedIds.ts
+++ b/backend/src/updatedIds.ts
@@ -84,7 +84,7 @@ export const initUpdateIndex =  async (): Promise<boolean> => {
 }
 
 export const updateFieldsToIndex =  async (updates: any): Promise<boolean> => {
-  if (Object.keys(updates).length === 0) return
+  if (Object.keys(updates).length === 0) return true
   const updateList: any = await resultsFromUpdates(updates)
   const bulkRequest = updateList.map((row: any) => { // TODO: type
     if (row.hits.hits.length > 0) {
@@ -212,7 +212,7 @@ export const addModification = async (id: string, modification: Modification, da
     await writeFileAsync(`${process.env.PROOFS}/${id}/${date}_${id}.json`, JSON.stringify(modification));
     if (!updatedFields[id]) { updatedFields[id] = [] }
     updatedFields[id].push(modification);
-    updateFieldsToIndex({[id]: updatedFields[id]});
+    await updateFieldsToIndex({[id]: updatedFields[id]});
     return true;
   } catch(e) {
     log({ msg: "Update failed", error: e.message, id, modification });

--- a/backend/src/updatedIds.ts
+++ b/backend/src/updatedIds.ts
@@ -1,5 +1,120 @@
 import { readFileSync, readdirSync, statSync } from 'fs';
 import path from "path";
+import axios from 'axios';
+import { runBulkRequest } from './runRequest';
+import { buildRequest } from './buildRequest';
+import { buildResultSingle, Result } from './models/result';
+import { RequestInput } from './models/requestInput';
+import { Modification } from './models/entities';
+import { promisify } from 'util';
+import { writeFile, access, mkdir } from 'fs';
+import { referenceSort } from './buildRequest';
+import loggerStream from './logger';
+
+const writeFileAsync = promisify(writeFile);
+const mkdirAsync = promisify(mkdir);
+const accessAsync = promisify(access);
+
+const updateIndex = 'deces-updates';
+const modelIndex = 'deces';
+let updateIndexCreated = false;
+
+const log = (json:any) => {
+    loggerStream.write(JSON.stringify({
+      "backend": {
+        "server-date": new Date(Date.now()).toISOString(),
+        ...json
+      }
+    }));
+}
+
+export const initUpdateIndex =  async (): Promise<boolean> => {
+  if (updateIndexCreated) { return true }
+  try {
+    const test = await axios(`http://elasticsearch:9200/${updateIndex}/_settings`);
+    if (test.status === 200) {
+      log({msg: `${updateIndex} already exists`});
+      updateIndexCreated = true;
+      return true;
+    }
+  } catch(e) {
+    // create index
+    const settingsResponse = await axios(`http://elasticsearch:9200/${modelIndex}/_settings`);
+    if (settingsResponse.status !== 200) {
+      log({msg: 'failed initiating missing update index', error: "coudn't retrive settings from model index"});
+      return false;
+    }
+    const analysis = settingsResponse.data && settingsResponse.data[modelIndex] &&
+      settingsResponse.data[modelIndex].settings.index && settingsResponse.data[modelIndex].settings.index.analysis;
+    if (!analysis) {
+      log({msg: 'failed initiating missing update index', error: "coudn't retrive settings from model index"});
+      return false
+    };
+    const mappingsResponse = await axios(`http://elasticsearch:9200/${modelIndex}/_mappings`);
+    if (mappingsResponse.status !== 200) {
+      log({msg: 'failed initiating missing update index', error: "coudn't retrive mappings from model index"});
+      return false;
+    }
+    const mappings = mappingsResponse.data && mappingsResponse.data[modelIndex] &&
+      mappingsResponse.data[modelIndex].mappings;
+    if (!mappings) {
+      log({msg: 'failed initiating missing update index', error: "coudn't retrive mappings from model index"});
+      return false;
+    };
+    try {
+      await axios(`http://elasticsearch:9200/${updateIndex}/`, {
+        method: 'PUT',
+        data: {
+          settings: { index: { analysis}},
+          mappings
+        },
+        headers: {
+          'Content-Type': 'application/x-ndjson',
+          'Cache-Control': 'no-cache'
+        }
+      });
+      updateIndexCreated = true;
+      log({msg: "initiated update index as didn't exists"});
+      return true;
+    } catch(err) {
+      log({msg: 'failed initiating missing update index', error: err.message});
+      return false;
+    }
+  }
+}
+
+export const updateFieldsToIndex =  async (updates: any): Promise<boolean> => {
+  if (Object.keys(updates).length === 0) return
+  const updateList: any = await resultsFromUpdates(updates)
+  const bulkRequest = updateList.map((row: any) => { // TODO: type
+    if (row.hits.hits.length > 0) {
+      const correctedUpdate = row.hits.hits[0]
+      const lastModif = updates[row.hits.hits[0]._id][updates[row.hits.hits[0]._id].length -1];
+      Object.keys(lastModif.fields).forEach((f: any) => {
+        if (referenceSort[f]) {
+          correctedUpdate._source[referenceSort[f].split('.')[0]] = lastModif.fields[f]
+        }
+      })
+      return [JSON.stringify({index: {_id: correctedUpdate._id}}), JSON.stringify(correctedUpdate._source)];
+    }
+  }).filter((x: any) => x);
+  const updateRequest = bulkRequest.map((x: any) => x.join('\n\r')).join('\n\r') + '\n';
+  const response = await axios(`http://elasticsearch:9200/${updateIndex}/_bulk`, {
+    method: 'POST',
+    data: updateRequest,
+    headers: {
+      'Content-Type': 'application/x-ndjson',
+      'Cache-Control': 'no-cache'
+    }
+  });
+  if (response.status === 200 && !response.data.errors) {
+    return true
+  } else {
+    log({msg: `Error adding documents to ${updateIndex}`, stack: JSON.stringify(response.data)});
+    return false
+  }
+}
+
 
 const walk = (directory: string): string[]=> {
   const fileList: string[] = [];
@@ -37,3 +152,70 @@ try {
     console.log('Failed loading updatedFields',e);
 }
 export const updatedFields: any = Object.keys(rawData).length ? rawData : {};
+
+export const getAllUpdates = (): any => {
+  return {...updatedFields};
+}
+
+export const getAuthorUpdates = (author: string):any => {
+  const updates:any = {};
+  Object.keys(updatedFields).forEach((id:any) => {
+    let keep = false;
+    const modifications = updatedFields[id].map((m:any) => {
+      const modif:any = {...m}
+      if (modif.author !== author) {
+        modif.author = modif.author ? modif.author.substring(0,2)
+          + '...' + modif.author.replace(/@.*/,'').substring(modif.author.replace(/@.*/,'').length-2)
+          + '@' + modif.author.replace(/.*@/,'') : '';
+        modif.message = undefined;
+        modif.review = undefined;
+      } else {
+        keep = true
+      }
+      return modif;
+    });
+    if (keep) {
+      updates[id] = modifications;
+    }
+  });
+  return updates;
+}
+
+export const resultsFromUpdates = async (updates: any): Promise<Result> => {
+  const bulkRequest = Object.keys(updates).map((id: any) =>
+    [JSON.stringify({index: "deces"}), JSON.stringify(buildRequest(new RequestInput({id})))]
+  );
+  const msearchRequest = bulkRequest.map((x: any) => x.join('\n\r')).join('\n\r') + '\n';
+  const result =  await runBulkRequest(msearchRequest);
+  return result.data.responses
+
+}
+
+export const cleanRawUpdates = (rawUpdates: any, updates: any): Promise<Result> => {
+  return rawUpdates.map((r:any) => buildResultSingle(r.hits.hits[0]))
+    .filter((r:any) => Object.keys(r).length > 0)
+    .map((r:any) => {
+      delete r.score;
+      delete r.scores;
+      r.modifications = updates[r.id];
+      return r;
+    });
+}
+
+export const addModification = async (id: string, modification: Modification, date: string): Promise<boolean> => {
+  try {
+    await accessAsync(`${process.env.PROOFS}/${id}`);
+  } catch(err) {
+    await mkdirAsync(`${process.env.PROOFS}/${id}`, { recursive: true });
+  }
+  try {
+    await writeFileAsync(`${process.env.PROOFS}/${id}/${date}_${id}.json`, JSON.stringify(modification));
+    if (!updatedFields[id]) { updatedFields[id] = [] }
+    updatedFields[id].push(modification);
+    updateFieldsToIndex({[id]: updatedFields[id]});
+    return true;
+  } catch(e) {
+    log({ msg: "Update failed", error: e.message, id, modification });
+    return false;
+  }
+}


### PR DESCRIPTION
* Use a second index to store modifications and show them in results.

![image](https://github.com/user-attachments/assets/d93ce229-9982-4d10-b15b-3c06da86c5af)

![image](https://github.com/user-attachments/assets/c1fd6773-91d9-4504-ad9e-4f079996170e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added support for update indices in Elasticsearch.
	- Introduced new methods for managing and retrieving updates.
	- Enhanced search functionality across multiple indices.

- **Improvements**
	- Expanded security model with additional user roles.
	- Improved error handling and logging mechanisms.
	- Optimized index management and update processing.
	- Enhanced clarity and efficiency in update handling and file storage.

- **Technical Updates**
	- Updated data models to include new index-related properties.
	- Refined search and update controllers.
	- Streamlined test suite for better coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->