### PR TITLE
fix catch bulk error in initial bulk when index not ready

### DIFF
--- a/backend/src/updatedIds.ts
+++ b/backend/src/updatedIds.ts
@@ -99,18 +99,23 @@ export const updateFieldsToIndex =  async (updates: any): Promise<boolean> => {
     }
   }).filter((x: any) => x);
   const updateRequest = bulkRequest.map((x: any) => x.join('\n\r')).join('\n\r') + '\n';
-  const response = await axios(`http://elasticsearch:9200/${updateIndex}/_bulk`, {
-    method: 'POST',
-    data: updateRequest,
-    headers: {
-      'Content-Type': 'application/x-ndjson',
-      'Cache-Control': 'no-cache'
+  try {
+    const response = await axios(`http://elasticsearch:9200/${updateIndex}/_bulk`, {
+      method: 'POST',
+      data: updateRequest,
+      headers: {
+        'Content-Type': 'application/x-ndjson',
+        'Cache-Control': 'no-cache'
+      }
+    });
+    if (response.status === 200 && !response.data.errors) {
+      return true
+    } else {
+      log({msg: `Error adding documents to ${updateIndex}`, stack: JSON.stringify(response.data)});
+      return false
     }
-  });
-  if (response.status === 200 && !response.data.errors) {
-    return true
-  } else {
-    log({msg: `Error adding documents to ${updateIndex}`, stack: JSON.stringify(response.data)});
+  } catch(e) {
+    log({msg: `Error adding documents to ${updateIndex}`, stack: e.message});
     return false
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error management for backend operations, improving overall system stability and minimizing the risk of unexpected interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->