### PR TITLE
🩹 Fix retry default response

### DIFF
--- a/backend/src/runRequest.ts
+++ b/backend/src/runRequest.ts
@@ -54,20 +54,22 @@ export const runRequest = async (body: BodyResponse|ScrolledResponse, scroll: st
 
       // if all attempts failed, or it is another error, return an error
       return {
-        hits: {
-          total: {
-            value: 1
-          },
-          hits: [
-            {
-              _id: 0,
-              _source: {
-                status: error.response?.status || 500,
-                statusText: error.response?.statusText || 'Internal Server Error',
-                error: true
+        data: {
+          hits: {
+            total: {
+              value: 1
+            },
+            hits: [
+              {
+                _id: 0,
+                _source: {
+                  status: error.response?.status || 500,
+                  statusText: error.response?.statusText || 'Internal Server Error',
+                  error: true
+                }
               }
-            }
-          ]
+            ]
+          }
         }
       };
     }

--- a/backend/src/runRequest.ts
+++ b/backend/src/runRequest.ts
@@ -109,20 +109,24 @@ export const runBulkRequest = async (body: any): Promise<any> => { // TODO defin
   });
   if (response.status >= 400) {
     return {
-      hits: {
-        total: {
-          value: 1
-        },
-        hits: [
-          {
-            _id: 0,
-            _source: {
-              status: response.status,
-              statusText: response.statusText,
-              error: true
-            }
+      data: {
+        responses: [{
+          hits: {
+            total: {
+              value: 1
+            },
+            hits: [
+              {
+                _id: 0,
+                _source: {
+                  status: response.status,
+                  statusText: response.statusText,
+                  error: true
+                }
+              }
+            ]
           }
-        ]
+        }]
       }
     };
   } else {


### PR DESCRIPTION
Actual default response after requests retries has the form:

```json
  hits: {
          total: {
            value: 1
          },
          hits: [
            {....
```

which generates an error with the `buildRequest` function, which uses a response with ` result.data.hits.hits` and not `results.hits.hits`:

``` typescript
const result = await runRequest(requestBuild, scroll);
const builtResult = buildResult(result.data, requestInput)
```

This PR fixes that and hopefully fixes #452 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated backend error responses to replace the `hits` object with a `data` object, maintaining the same nested error information. This change enhances the clarity of error messaging, contributing to a smoother diagnostic process while preserving core error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->