### PR TITLE
✨ Add url for swagger file in documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,9 @@ export PORT=8084
 export BACKEND=${APP_PATH}/backend
 export BACKEND_PORT=8080
 export BACKEND_HOST=backend
-export APP_URL?=https://${APP_DNS}
-export API_URL?=localhost:${PORT}
-export API_EMAIL?=matchid.project@gmail.com
 export API_SSL?=1
+export APP_URL?=http$([ "$API_SSL" == 1 ] && echo "s" || echo "")://${APP_DNS}
+export API_EMAIL?=matchid.project@gmail.com
 export BACKEND_TOKEN_USER?=${API_EMAIL}
 export BACKEND_TOKEN_KEY?=$(shell echo $$RANDOM )
 export BACKEND_TOKEN_PASSWORD?=$(shell echo $$RANDOM )

--- a/backend/src/controllers/documentation.ts
+++ b/backend/src/controllers/documentation.ts
@@ -13,7 +13,7 @@ const swaggerDefinitionTemplate: any = {
     title: "API personnes décédées",
     version: process.env.APP_VERSION,
     description:
-    "API pour faciliter le rapprochement des personnes decedees",
+    `API pour faciliter le rapprochement des personnes decedees\n \n Swagger File: [${process.env.API_URL}/deces/api/v1/docs/swagger.json](http${process.env.API_SSL && process.env.API_SSL === "1" ? 's' : ''}://${process.env.API_URL}/deces/api/v1/docs/swagger.json)`,
     license: {
       name: "lgpl-3.0",
       url: "https://choosealicense.com/licenses/lgpl-3.0/"
@@ -40,7 +40,7 @@ options.swaggerDefinition.openapi = '3.0.0'
 const specs: any = swaggerJsdoc(options);
 
 // publish swagger json (optional)
-router.get(`/bulk.json`, (_, res: any) => res.send(specs));
+router.get(`/swagger.json`, (_, res: any) => res.send(specs));
 router.get(`/tsoa.json`, (_, res: any) => res.send(swaggerDocument));
 
 specs.paths = {...specs.paths, ...swaggerDocument.paths}

--- a/backend/src/controllers/documentation.ts
+++ b/backend/src/controllers/documentation.ts
@@ -13,20 +13,20 @@ const swaggerDefinitionTemplate: any = {
     title: "API personnes décédées",
     version: process.env.APP_VERSION,
     description:
-    `API pour faciliter le rapprochement des personnes decedees\n \n Swagger File: [${process.env.API_URL}/deces/api/v1/docs/swagger.json](http${process.env.API_SSL && process.env.API_SSL === "1" ? 's' : ''}://${process.env.API_URL}/deces/api/v1/docs/swagger.json)`,
+    `API pour faciliter le rapprochement des personnes decedees\n \n Swagger File: [${process.env.APP_URL}/deces/api/v1/docs/swagger.json](${process.env.APP_URL}/deces/api/v1/docs/swagger.json)`,
     license: {
       name: "lgpl-3.0",
       url: "https://choosealicense.com/licenses/lgpl-3.0/"
     },
     contact: {
       name: "MatchID",
-      url: `http${process.env.API_SSL && process.env.API_SSL === "1" ? 's' : ''}://${process.env.API_URL}`,
+      url: `${process.env.APP_URL}`,
       email: `${process.env.API_EMAIL}`
     }
   },
   servers: [
     {
-      url: `http${process.env.API_SSL && process.env.API_SSL === "1" ? 's' : ''}://${process.env.API_URL}/deces/api/v1`,
+      url: `${process.env.APP_URL}/deces/api/v1`,
       description: "Backend API URL"
     }
   ]

--- a/backend/src/tsoa.ts
+++ b/backend/src/tsoa.ts
@@ -4,7 +4,7 @@ import { generateRoutes, generateSpec, ExtendedRoutesConfig, ExtendedSpecConfig 
 (async () => {
   const specOptions: ExtendedSpecConfig = {
     basePath: "/api",
-    host: `${process.env.API_URL}`,
+    host: `${process.env.APP_URL}`,
     entryFile: './src/index.ts',
     specVersion: 3,
     outputDirectory: './src/api',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,6 @@ services:
       - SMTP_PORT=${SMTP_PORT}
       - SMTP_USER=${SMTP_USER}
       - SMTP_PWD=${SMTP_PWD}
-      - API_URL=${API_URL}
       - API_SSL=${API_SSL}
       - API_EMAIL=${API_EMAIL}
       - DATAGOUV_CATALOG_URL=${DATAGOUV_CATALOG_URL}


### PR DESCRIPTION
* Feature: Add url for swagger file (with a better name)
* Fix: Use APP_URL variable, since API_URL is not passed in prod deployment to the backend. I propose to clean this variable from the frontend here: https://github.com/matchID-project/deces-ui/pull/955

![image](https://github.com/user-attachments/assets/cd5471e7-b01e-47e8-9a6b-06f8347f18d5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved URL handling by ensuring all references now consistently use a single environment variable for the application URL, automatically adapting to SSL settings.
	- Updated API documentation to provide direct links and accurate server URLs.
	- Renamed the Swagger JSON endpoint for clarity.

- **Chores**
	- Cleaned up environment variable usage and configuration files for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->