### PR TITLE
enable exaclty 12 month token renewal

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -62,7 +62,7 @@ export class AuthController extends Controller {
           access_token: accessToken,
           created_at: decoded.jti,
           expiration_date: decoded.exp.toString(),
-          renewal_limit_date: (Number(decoded.jti) + 2592000 * 11).toString()
+          renewal_limit_date: (Number(decoded.jti) + 2592000 * 12).toString()
         }
       }
     } else if ((Object.keys(userDB).indexOf(jsonToken.user)>=0) && (userDB[jsonToken.user] === crypto.createHash('sha256').update(jsonToken.password).digest('hex'))) {
@@ -73,7 +73,7 @@ export class AuthController extends Controller {
           access_token: accessToken,
           created_at: decoded.jti,
           expiration_date: decoded.exp.toString(),
-          renewal_limit_date: (Number(decoded.jti) + 2592000 * 11).toString()
+          renewal_limit_date: (Number(decoded.jti) + 2592000 * 12).toString()
       }
     } else if (validateOTP(jsonToken.user,jsonToken.password)) {
       const accessToken = jwt.sign({...jsonToken, scopes: ['user']}, process.env.BACKEND_TOKEN_KEY, { expiresIn: "30d", jwtid: Math.floor(Date.now() / 1000).toString() })
@@ -83,7 +83,7 @@ export class AuthController extends Controller {
           access_token: accessToken,
           created_at: decoded.jti,
           expiration_date: decoded.exp.toString(),
-          renewal_limit_date: (Number(decoded.jti) + 2592000 * 11).toString()
+          renewal_limit_date: (Number(decoded.jti) + 2592000 * 12).toString()
       }
     }
     this.setStatus(401);
@@ -110,12 +110,12 @@ export class AuthController extends Controller {
       try {
         let decoded: any = jwt.verify(token, process.env.BACKEND_TOKEN_KEY)
         const now = Math.floor(Date.now() / 1000)
-        // refresh until 11 month of creation
-        const oneYearAftercreation = Number(decoded.jti) + 2592000 * 11;
+        const oneYearAftercreation = Number(decoded.jti) + 2592000 * 12;
         if (now < oneYearAftercreation) {
           delete decoded.exp;
           delete decoded.iat;
-          const accessToken = jwt.sign(decoded, process.env.BACKEND_TOKEN_KEY, { expiresIn: "30d" });
+          const expiresInSeconds = Math.min(2592000, oneYearAftercreation - now);
+          const accessToken = jwt.sign(decoded, process.env.BACKEND_TOKEN_KEY, { expiresIn: expiresInSeconds });
           decoded = jwt.verify(accessToken, process.env.BACKEND_TOKEN_KEY)
           return {
             msg: "jwt has been properly renewed",
@@ -142,7 +142,7 @@ export class AuthController extends Controller {
         msg: "jwt is valid",
         created_at: decoded.jti,
         expiration_date: decoded.exp.toString(),
-        renewal_limit_date: (Number(decoded.jti) + 2592000 * 11).toString()
+        renewal_limit_date: (Number(decoded.jti) + 2592000 * 12).toString()
       }
     }
   }


### PR DESCRIPTION
The token renewal system has been improved to fix #443 the 1-year expiration logic.

Before the fix:
├── Initial Token (Day 0)
│   ├── Daily renewals for 11 months
│   └── Last month: Renewal blocked ❌
│       (Forced to stop daily updates)
└── Total: 334 days of possible renewals

After the fix:
├── Initial Token (Day 0)
│   ├── Daily renewals for 12 months
│   └── Continuous renewal possible ✅
│       (No interruption needed)
└── Total: 365 days of possible renewals

Real-world analogy:
- Before: Like a subscription that stops working in the last month
- After: Like a subscription that works smoothly for the entire year

This change ensures that:
1. You can renew your token every day for the full 12 months
2. No need to interrupt your daily renewal process
3. Maximum flexibility within the 1-year limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Extended the renewal limit for JWT tokens from 11 months to 12 months (one year).
  - Token expiration for refresh is now dynamically set based on the remaining renewal period, up to a maximum of 30 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->