### PR TITLE
Integrate Auth0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,19 @@ Before starting a database has to be charged in elasticsearch. Please refer to
 Source code has been published using [LGPL 3.0](https://github.com/matchID-project/deces-backend/blob/dev/LICENCE).
 
 © 2020 Cristian Brokate, DNUM - SDIT
+
+## Authentification
+
+Depuis cette version, l'API utilise **Auth0** en mode passwordless.
+Configurez les variables d'environnement suivantes pour votre tenant :
+
+```
+AUTH0_DOMAIN=<votre domaine>
+AUTH0_CLIENT_ID=<identifiant client>
+AUTH0_CLIENT_SECRET=<secret client>
+AUTH0_AUDIENCE=<audience de l'API>
+```
+
+Les points de terminaison `/register` et `/auth` s'appuient sur les services
+`passwordless/start` et `oauth/token` d'Auth0. Un jeton d'API peut être généré
+via la route protégée `/apikey` en indiquant la durée souhaitée de validité.

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "iconv-lite": "^0.6.3",
     "JSONStream": "^1.3.5",
     "jsonwebtoken": "^9.0.2",
+    "jwks-rsa": "^3.2.0",
     "morgan": "^1.10.0",
     "multer": "^1.4.5-lts.1",
     "node-forge": "^1.3.1",

--- a/backend/src/auth0.ts
+++ b/backend/src/auth0.ts
@@ -1,0 +1,54 @@
+import axios from 'axios';
+import * as jwks from 'jwks-rsa';
+import * as jwt from 'jsonwebtoken';
+
+export const auth0Client = jwks.createRemoteJWKSet(new URL(`https://${process.env.AUTH0_DOMAIN}/.well-known/jwks.json`));
+
+export async function verifyAuth0Token(token: string): Promise<any> {
+  return await jwt.verify(token, async (header, callback) => {
+    try {
+      const key = await auth0Client.getKey(header as any);
+      callback(null, key.publicKey || key.rsaPublicKey);
+    } catch (err) {
+      callback(err as any, undefined);
+    }
+  }, {
+    audience: process.env.AUTH0_AUDIENCE,
+    issuer: `https://${process.env.AUTH0_DOMAIN}/`,
+    algorithms: ['RS256']
+  });
+}
+
+export async function sendAuth0OTP(email: string) {
+  const res = await axios.post(`https://${process.env.AUTH0_DOMAIN}/passwordless/start`, {
+    client_id: process.env.AUTH0_CLIENT_ID,
+    connection: 'email',
+    send: 'code',
+    email
+  });
+  return res.data;
+}
+
+export async function verifyAuth0OTP(email: string, otp: string) {
+  const res = await axios.post(`https://${process.env.AUTH0_DOMAIN}/oauth/token`, {
+    grant_type: 'http://auth0.com/oauth/grant-type/passwordless/otp',
+    client_id: process.env.AUTH0_CLIENT_ID,
+    otp,
+    realm: 'email',
+    username: email,
+    audience: process.env.AUTH0_AUDIENCE,
+    scope: 'openid profile email offline_access'
+  });
+  return res.data;
+}
+
+export async function createApiKey(expiresIn: number) {
+  const res = await axios.post(`https://${process.env.AUTH0_DOMAIN}/oauth/token`, {
+    client_id: process.env.AUTH0_CLIENT_ID,
+    client_secret: process.env.AUTH0_CLIENT_SECRET,
+    audience: process.env.AUTH0_AUDIENCE,
+    grant_type: 'client_credentials',
+    expires_in: expiresIn
+  });
+  return res.data;
+}


### PR DESCRIPTION
## Summary
- integrate Auth0 helper
- use Auth0 verification in authentication middleware
- update auth controller to use Auth0 for OTP and API key generation
- add Auth0 docs
- add jwks-rsa dependency

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6843ae7f03c48325b70c311384cfbd78