### PR TITLE
Add rate limit for OTP email sending

### DIFF
--- a/backend/src/mail.spec.ts
+++ b/backend/src/mail.spec.ts
@@ -32,9 +32,16 @@ describe('mail.ts - Sending emails', () => {
   }, 10000);
 
   it('Send test email fake smtp server', async () => {
-    const res = await sendOTP("recipient@example.com")
+    let res: any;
+    res = await sendOTP("recipient@example.com")
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     expect(res.valid).to.be.true;
+    
+    // Test rate limit: second send should fail with rate limit message
+    res = await sendOTP("recipient@example.com")
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    expect(res.valid).to.be.false;
+    expect(res.msg).to.include('attendre');
   })
 
   it('Send test email fake smtp server to a disposable address', async () => {

--- a/backend/src/mail.spec.ts
+++ b/backend/src/mail.spec.ts
@@ -36,7 +36,7 @@ describe('mail.ts - Sending emails', () => {
     res = await sendOTP("recipient@example.com")
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     expect(res.valid).to.be.true;
-    
+
     // Test rate limit: second send should fail with rate limit message
     res = await sendOTP("recipient@example.com")
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions


### PR DESCRIPTION
Ajouter une restriction sur la fonction d'envoi d'OTP : le délai d'attente, fixé initialement à une minute, devra croître de manière exponentielle si un e-mail a été envoyé récemment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests validating rate limits on repeated OTP sends.

* **Bug Fixes**
  * Enforced rate limiting for OTP requests to prevent abuse.
  * Added exponential backoff that increases wait times for repeated requests.
  * Improved user-facing messages that state how long to wait before retrying.
  * Enforced OTP expiry to remove old codes automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->